### PR TITLE
fix(workflow): dispatch executors by blockId and collapse duplicate history steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Dependencies
 node_modules/
 .pnpm-store/
+.pnpm-store-local/
+.pnpm-tmp/
 
 # Build output
 dist/

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -1,5 +1,8 @@
 import { defineManifest } from '@crxjs/vite-plugin'
 
+/** Flat typing of the crxjs manifest parameter (used to include the MV3 `offscreen` key). */
+type ManifestParam = Parameters<typeof defineManifest>[0]
+
 /**
  * MV3 manifest.
  *
@@ -37,7 +40,7 @@ export default defineManifest({
   description:
     'A side-panel assistant that can read and act on the page you are looking at. Works with any OpenAI-compatible model.',
   minimum_chrome_version: '116',
-  permissions: ['storage', 'tabs', 'scripting', 'sidePanel', 'alarms'],
+  permissions: ['storage', 'tabs', 'scripting', 'sidePanel', 'alarms', 'offscreen', 'contextMenus', 'webNavigation', 'cookies', 'downloads', 'clipboardRead'],
   host_permissions: ['http://*/*', 'https://*/*'],
   icons: {
     16: 'icons/icon-16.png',
@@ -61,4 +64,9 @@ export default defineManifest({
   side_panel: {
     default_path: 'src/sidepanel/index.html',
   },
-})
+  offscreen: {
+    document_url: 'src/offscreen/index.html',
+    justification:
+      'Used by the clipboard workflow block to read/write the system clipboard without disturbing the active page.',
+  },
+} as unknown as ManifestParam)

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "icons": "node scripts/generate-icons.mjs"
   },
   "dependencies": {
+    "@xyflow/react": "^12.11.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@xyflow/react':
+        specifier: ^12.11.5
+        version: 12.11.5(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: ^19.2.0
         version: 19.2.8
@@ -310,7 +313,6 @@ packages:
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
@@ -349,79 +351,66 @@ packages:
     resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.4':
     resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.4':
     resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.4':
     resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.4':
     resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.4':
     resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.4':
     resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.4':
     resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.4':
     resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.4':
     resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.4':
     resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.4':
     resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.4':
     resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
@@ -470,6 +459,24 @@ packages:
 
   '@types/chrome@0.0.312':
     resolution: {integrity: sha512-m204djOoU/YqF1dRw3YLk2L3tcDTYREUERDQDUAmROK3Rv94nLbMJ4uvjzr/Yj/A7SyEpTrpoCuXBKTuerEdqg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -535,6 +542,22 @@ packages:
   '@webcomponents/custom-elements@1.6.0':
     resolution: {integrity: sha512-CqTpxOlUCPWRNUPZDxT5v2NnHXA4oox612iUGnmTUGQFhZ1Gkj8kirtl/2wcF6MqX7+PqqicZzOCBKKfIn0dww==}
 
+  '@xyflow/react@12.11.5':
+    resolution: {integrity: sha512-QqoryGkqEhWBuQN9bZWRKhwr3Uoj9lCGj/tg0NnIWHHEOXV+5c8cYsc7Q9TST63V92lHqcNV9P5cjvJ9ZAmblQ==}
+    peerDependencies:
+      '@types/react': '>=17'
+      '@types/react-dom': '>=17'
+      react: '>=17'
+      react-dom: '>=17'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@xyflow/system@0.0.81':
+    resolution: {integrity: sha512-hfbafW4i7uLq7ILok8QWFFm4KMFw22lbZNJHKfHOMSOOoCk5e5m8yfr84UV9NaJajmogWaLVnp2XFU9JQejlqg==}
+
   acorn-walk@8.3.5:
     resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
@@ -576,6 +599,9 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -588,6 +614,44 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -829,6 +893,11 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -909,6 +978,21 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
 snapshots:
 
@@ -1252,6 +1336,27 @@ snapshots:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16
 
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
@@ -1332,6 +1437,31 @@ snapshots:
 
   '@webcomponents/custom-elements@1.6.0': {}
 
+  '@xyflow/react@12.11.5(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@xyflow/system': 0.0.81
+      classcat: 5.0.5
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      zustand: 4.5.7(@types/react@19.2.18)(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
+    transitivePeerDependencies:
+      - immer
+
+  '@xyflow/system@0.0.81':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   acorn-walk@8.3.5:
     dependencies:
       acorn: 8.18.0
@@ -1366,6 +1496,8 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  classcat@5.0.5: {}
+
   convert-source-map@2.0.0: {}
 
   css-select@5.2.2:
@@ -1379,6 +1511,42 @@ snapshots:
   css-what@6.2.2: {}
 
   csstype@3.2.3: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   debug@4.4.3:
     dependencies:
@@ -1615,6 +1783,10 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  use-sync-external-store@1.6.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+
   vite-node@3.2.4(@types/node@26.2.0):
     dependencies:
       cac: 6.7.14
@@ -1695,3 +1867,10 @@ snapshots:
       stackback: 0.0.2
 
   yallist@3.1.1: {}
+
+  zustand@4.5.7(@types/react@19.2.18)(react@19.2.8):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      react: 19.2.8

--- a/src/background/agent.ts
+++ b/src/background/agent.ts
@@ -610,6 +610,7 @@ async function recordAction(
   approved: boolean,
   ok: boolean,
   detail?: string[],
+  args?: Record<string, unknown>,
 ): Promise<void> {
   try {
     await addHistory({
@@ -622,6 +623,7 @@ async function recordAction(
       approved,
       ok,
       ...(detail && detail.length > 0 ? { detail } : {}),
+      ...(args && typeof args === 'object' ? { args } : {}),
     })
   } catch {
     /* non-fatal */
@@ -1395,7 +1397,7 @@ async function runOneToolCall(
       name,
       summary: inChat ? 'Blocked (chat mode)' : 'Blocked (read-only mode)',
     })
-    void recordAction(
+    await recordAction(
       deps.conversationId,
       name,
       describeAction(name, args),
@@ -1403,6 +1405,7 @@ async function runOneToolCall(
       false,
       false,
       describeDetail(name, args),
+      args,
     )
     return
   }
@@ -1433,7 +1436,7 @@ async function runOneToolCall(
       if (!approved) {
         pushResult(JSON.stringify({ error: 'The user declined this action. Do not retry it.' }))
         deps.send({ type: 'tool.result', name, summary: 'Declined by user' })
-        void recordAction(
+        await recordAction(
           deps.conversationId,
           name,
           describeAction(name, args),
@@ -1441,6 +1444,7 @@ async function runOneToolCall(
           false,
           false,
           describeDetail(name, args),
+          args,
         )
         return
       }
@@ -1459,7 +1463,7 @@ async function runOneToolCall(
     } catch {
       /* keep ok */
     }
-    void recordAction(
+    await recordAction(
       deps.conversationId,
       name,
       describeAction(name, args),
@@ -1467,6 +1471,7 @@ async function runOneToolCall(
       approved,
       ok,
       describeDetail(name, args, output),
+      args,
     )
   } catch (error) {
     // A termination must unwind the whole turn, not be recorded as a failed
@@ -1480,7 +1485,7 @@ async function runOneToolCall(
           : String(error)
     pushResult(JSON.stringify({ error: message }))
     deps.send({ type: 'tool.result', name, summary: `Failed: ${message}` })
-    void recordAction(
+    await recordAction(
       deps.conversationId,
       name,
       describeAction(name, args),
@@ -1488,6 +1493,7 @@ async function runOneToolCall(
       approved,
       false,
       [...describeDetail(name, args), `Error: ${message}`],
+      args,
     )
   }
 }

--- a/src/background/driver.ts
+++ b/src/background/driver.ts
@@ -211,3 +211,131 @@ export async function closeActiveTab(): Promise<void> {
   const tab = await activeTab()
   if (tab?.id) await chrome.tabs.remove(tab.id)
 }
+
+export async function goBack(): Promise<void> {
+  const tab = await activeTab()
+  if (!tab || typeof tab.id !== 'number') throw new DriverError('没有可后退的活动标签页')
+  await chrome.tabs.goBack(tab.id)
+}
+
+export async function goForward(): Promise<void> {
+  const tab = await activeTab()
+  if (!tab || typeof tab.id !== 'number') throw new DriverError('没有可前进的活动标签页')
+  await chrome.tabs.goForward(tab.id)
+}
+
+export interface DriverTabInfo {
+  id: number
+  url: string
+  title: string
+  active: boolean
+}
+
+export async function getActiveTabInfo(): Promise<DriverTabInfo> {
+  const tab = await activeTab()
+  if (!tab || typeof tab.id !== 'number') throw new DriverError('没有活动标签页')
+  return toDriverTab(tab)
+}
+
+export async function listAllTabUrls(): Promise<{ id: number; url: string; title: string }[]> {
+  const tabs = await chrome.tabs.query({ currentWindow: true })
+  return tabs
+    .filter((tab) => typeof tab.id === 'number')
+    .map((tab) => ({ id: tab.id as number, url: tab.url ?? '', title: tab.title ?? '' }))
+}
+
+export async function newWindow(url?: string): Promise<chrome.windows.Window> {
+  return chrome.windows.create({ url, focused: true })
+}
+
+/** Checks whether a CSS selector matches any element in the active tab. */
+export async function elementExists(
+  selector: string,
+  signal?: AbortSignal,
+): Promise<number> {
+  const result = await execOnActiveTab({ action: 'element_exists', value: selector }, signal)
+  return typeof result.data === 'number' ? result.data : result.found ? 1 : 0
+}
+
+/** Counts elements matching a CSS selector in the active tab. */
+export async function countElements(
+  selector: string,
+  signal?: AbortSignal,
+): Promise<number> {
+  const result = await execOnActiveTab({ action: 'count_elements', value: selector }, signal)
+  return typeof result.data === 'number' ? result.data : 0
+}
+
+// --- Cookie helpers (service-worker side, no page needed) --------------------
+
+export async function cookieGetAll(url?: string): Promise<chrome.cookies.Cookie[]> {
+  return chrome.cookies.getAll(url ? { url } : {})
+}
+
+export async function cookieGet(name: string, url?: string): Promise<chrome.cookies.Cookie | null> {
+  const tab = await activeTab()
+  const targetUrl = url ?? tab?.url
+  if (!targetUrl) throw new DriverError('cookie: 需要 URL 才能读取')
+  return chrome.cookies.get({ name, url: targetUrl })
+}
+
+export async function cookieSet(
+  name: string,
+  value: string,
+  url: string,
+  options: { expirationDate?: number } = {},
+): Promise<void> {
+  await chrome.cookies.set({
+    url,
+    name,
+    value,
+    ...(options.expirationDate !== undefined ? { expirationDate: options.expirationDate } : {}),
+  })
+}
+
+export async function cookieRemove(name: string, url: string): Promise<void> {
+  await chrome.cookies.remove({ name, url })
+}
+
+// --- Clipboard helpers (offscreen document) ----------------------------------
+
+let offscreenOpen = false
+
+async function ensureOffscreen(): Promise<void> {
+  const has = await chrome.offscreen.hasDocument()
+  if (has) {
+    offscreenOpen = true
+    return
+  }
+  await chrome.offscreen.createDocument({
+    url: 'src/offscreen/index.html',
+    reasons: ['CLIPBOARD'],
+    justification: 'read/write the system clipboard for the workflow clipboard block',
+  })
+  offscreenOpen = true
+}
+
+interface ClipReply {
+  ok: boolean
+  text?: string
+  error?: string
+}
+
+async function clipboardCall(message: { type: 'clip-get' } | { type: 'clip-set'; text: string }): Promise<string> {
+  await ensureOffscreen()
+  const reply = await chrome.runtime.sendMessage(message)
+  const result = reply as ClipReply | undefined
+  if (!result || !result.ok) {
+    throw new DriverError(`clipboard: ${result?.error ?? '操作失败'}`)
+  }
+  return result.text ?? ''
+}
+
+export async function clipboardGet(): Promise<string> {
+  return clipboardCall({ type: 'clip-get' })
+}
+
+export async function clipboardInsert(text: string): Promise<void> {
+  await clipboardCall({ type: 'clip-set', text })
+  void offscreenOpen
+}

--- a/src/background/feishu-bot.ts
+++ b/src/background/feishu-bot.ts
@@ -63,7 +63,10 @@ import {
   type Frame,
 } from '../lib/feishu-proto'
 import { getFeishuConfig, listTasks } from '../lib/task-store'
+import { listWorkflows } from '../lib/workflow/storage'
+import type { Workflow } from '../lib/workflow/types'
 import { triggerNow } from './scheduler'
+import { executeWorkflow } from './workflow-engine/run-workflow'
 import { runUnattendedPrompt } from './agent-unattended'
 import {
   addStep,
@@ -91,6 +94,9 @@ export const COMMAND_PATTERNS = [
   /run task|执行任务|运行任务/i,
   /status|状态/i,
 ]
+
+/** Slash-style command that runs a named workflow by id or name. */
+export const WORKFLOW_COMMAND = /^\s*(?:\/run\s+workflow|\/workflow|运行工作流|执行工作流)[：: ]?\s*(.+)$/i
 
 /** True when an inbound message text should trigger a task run. Exported for tests. */
 export function isCommand(text: string): boolean {
@@ -485,6 +491,22 @@ export class FeishuBot {
     const token = await this.tokenProvider.get().catch(() => null)
     if (!token) return
 
+    // 0. Workflow command? A `/workflow <name>` (or Chinese equivalent) runs a
+    //    saved workflow directly. Checked before named tasks so a workflow whose
+    //    name collides with a task name still wins when the command form is used.
+    const wfMatch = WORKFLOW_COMMAND.exec(text)
+    if (wfMatch) {
+      const nameOrId = wfMatch[1]!.trim()
+      const wf = (await listWorkflows()).find(
+        (w) => w.id === nameOrId || w.name.toLowerCase() === nameOrId.toLowerCase(),
+      )
+      if (wf) {
+        await safeReply(token, message.chatId, '▶ 开始执行工作流')
+        await this.runWorkflowAndReport(token, message.chatId, wf)
+        return
+      }
+    }
+
     // 1. Named task? If the message mentions a saved task name, run that task.
     const tasks = await listTasks()
     const named = tasks.find(
@@ -611,6 +633,45 @@ export class FeishuBot {
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error)
       await safeReply(token, chatId, `Task failed: ${detail}`)
+    }
+  }
+
+  /**
+   * Runs a saved workflow triggered from Feishu and reports its progress. Unlike
+   * `runAndReport` (which polls the board for a task's own run), a workflow is
+   * executed inline here — `executeWorkflow` registers its own run on the board
+   * and we stream its engine steps to the chat before replying with the outcome.
+   */
+  private async runWorkflowAndReport(
+    token: string,
+    chatId: string,
+    wf: Workflow,
+  ): Promise<void> {
+    const streamer = new StepStreamer(token, chatId)
+    streamer.start()
+    try {
+      const result = await executeWorkflow(wf, {
+        source: 'feishu',
+        feishuChatId: chatId,
+        onStep: (_kind, nodeId, text) => {
+          streamer.push(text)
+          streamer.push('→ ' + nodeId)
+        },
+      })
+      streamer.flush()
+      if (result.outcome === 'cancelled') {
+        await safeReply(token, chatId, '⏹ 工作流已终止。')
+      } else if (result.outcome === 'failed') {
+        await safeReply(token, chatId, result.summary || '工作流执行失败。')
+      } else {
+        await sendImText(token, chatId, result.summary || `✅ 工作流「${wf.name}」执行完成。`)
+      }
+    } catch (error) {
+      streamer.flush()
+      const detail = error instanceof Error ? error.message : String(error)
+      await safeReply(token, chatId, `工作流执行失败：${detail}`)
+    } finally {
+      streamer.stop()
     }
   }
 

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -64,6 +64,13 @@ import {
   saveFeishuConfig,
   saveTask,
 } from '../lib/task-store'
+import {
+  listWorkflows,
+  getWorkflow,
+  saveWorkflow,
+  deleteWorkflow,
+} from '../lib/workflow/storage'
+import { executeWorkflow } from './workflow-engine/run-workflow'
 import { rescheduleAll, scheduleTask, triggerNow, onAlarm } from './scheduler'
 import { FeishuBot, FEISHU_WATCHDOG_ALARM } from './feishu-bot'
 import { isWebhookUrl, sendWebhookText } from '../lib/feishu'
@@ -94,6 +101,7 @@ setFinishedPersister((run: FinishedTask) => {
     finishedAt: run.finishedAt,
     outcome: run.outcome,
     summary: run.summary,
+    ...(run.error ? { error: run.error } : {}),
     steps: run.steps,
   }).catch((error: unknown) => {
     console.error('[Browser Copilot] could not persist finished run', error)
@@ -130,6 +138,11 @@ chrome.runtime.onInstalled.addListener(() => {
   void rescheduleAll().catch((error: unknown) =>
     console.error('[Browser Copilot] could not reschedule tasks', error),
   )
+  if (chrome.contextMenus) {
+    void registerContextMenuWorkflows().catch((error: unknown) =>
+      console.error('[Browser Copilot] could not register context-menu workflows', error),
+    )
+  }
 })
 
 // A worker update/startup must also reconcile alarms: chrome.alarms persist across
@@ -160,6 +173,98 @@ chrome.alarms.onAlarm.addListener((alarm) => {
 
 /** Single long-lived Feishu bot connection (reconnects internally). */
 const feishuBot = new FeishuBot()
+
+// --- Workflow trigger listeners ------------------------------------------------
+
+/**
+ * (Re)creates a right-click context-menu item for every enabled workflow whose
+ * trigger is `context-menu`. Rebuilding from scratch keeps the menu in sync with
+ * storage: deleted workflows vanish, renames update the label, re-enabled ones
+ * reappear.
+ */
+async function registerContextMenuWorkflows(): Promise<void> {
+  const workflows = (await listWorkflows()).filter(
+    (wf) => wf.trigger?.type === 'context-menu' && wf.trigger.enabled !== false,
+  )
+  try {
+    chrome.contextMenus.removeAll()
+  } catch {
+    /* may already be cleared */
+  }
+  for (const wf of workflows) {
+    try {
+      chrome.contextMenus.create({
+        id: wf.trigger?.menuItemId ?? wf.id,
+        title: wf.name,
+        contexts: ['page'],
+      })
+    } catch (error) {
+      console.error('[Browser Copilot] could not create context menu item', wf.id, error)
+    }
+  }
+}
+
+/**
+ * Runs a workflow, holding the worker alive for the duration so a context-menu
+ * click or navigation that triggers it cannot strand the run mid-way.
+ */
+async function runWorkflowKeepalive(workflowId: string): Promise<void> {
+  const wf = await getWorkflow(workflowId)
+  if (!wf) return
+  retain()
+  try {
+    await executeWorkflow(wf, { source: 'manual' })
+  } finally {
+    release()
+  }
+}
+
+// Right-click "run workflow" items. Guarded: the API is not present in tests and
+// may be unavailable on some builds.
+if (chrome.contextMenus?.onClicked) {
+  chrome.contextMenus.onClicked.addListener((info) => {
+    void (async () => {
+      try {
+        const workflows = await listWorkflows()
+        const wf = workflows.find(
+          (w) =>
+            w.trigger?.type === 'context-menu' &&
+            (w.trigger.menuItemId !== undefined ? w.trigger.menuItemId === info.menuItemId : w.id === info.menuItemId),
+        )
+        if (wf) await runWorkflowKeepalive(wf.id)
+      } catch (error) {
+        console.error('[Browser Copilot] context-menu workflow failed', error)
+      }
+    })()
+  })
+}
+
+// Visit-web workflows: fire when a matching page commits navigation. Defensive —
+// ignore any scheme other than http(s), and fall back to substring matching if
+// the stored pattern is not a valid regular expression.
+if (chrome.webNavigation?.onCommitted) {
+  chrome.webNavigation.onCommitted.addListener((details) => {
+    void (async () => {
+      try {
+        const url = details.url
+        if (!/^https?:/i.test(url)) return
+        const href = new URL(url).href
+        const workflows = await listWorkflows()
+        const wf = workflows.find((w) => {
+          if (w.trigger?.type !== 'visit-web' || !w.trigger.urlPattern) return false
+          try {
+            return new RegExp(w.trigger.urlPattern).test(href)
+          } catch {
+            return href.includes(w.trigger.urlPattern)
+          }
+        })
+        if (wf) await runWorkflowKeepalive(wf.id)
+      } catch (error) {
+        console.error('[Browser Copilot] visit-web workflow failed', error)
+      }
+    })()
+  })
+}
 
 /** Records an agent step onto a running-task board entry, ignoring stale runs. */
 function recordStep(
@@ -226,6 +331,34 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   // Keeps the response channel open for the async work above.
   return true
 })
+
+function runningBoardsView(): {
+  runs: { runId: string; taskId?: string; label: string; source: ReturnType<typeof listRunning>[number]['source']; startedAt: number; steps: ReturnType<typeof listRunning>[number]['steps'] }[]
+  finished: { runId: string; taskId?: string; label: string; source: ReturnType<typeof listFinished>[number]['source']; startedAt: number; finishedAt: number; outcome: ReturnType<typeof listFinished>[number]['outcome']; summary?: string; steps: ReturnType<typeof listFinished>[number]['steps'] }[]
+} {
+  const mapFinished = (r: ReturnType<typeof listFinished>[number]) => ({
+    runId: r.runId,
+    taskId: r.taskId,
+    label: r.label,
+    source: r.source,
+    startedAt: r.startedAt,
+    finishedAt: r.finishedAt,
+    outcome: r.outcome,
+    summary: r.summary,
+    steps: r.steps,
+  })
+  return {
+    runs: listRunning().map((r) => ({
+      runId: r.runId,
+      taskId: r.taskId,
+      label: r.label,
+      source: r.source,
+      startedAt: r.startedAt,
+      steps: r.steps,
+    })),
+    finished: listFinished().map(mapFinished),
+  }
+}
 
 async function handleCommand(command: Command): Promise<CommandResult> {
   switch (command.type) {
@@ -402,31 +535,8 @@ async function handleCommand(command: Command): Promise<CommandResult> {
       await deleteRun(command.id)
       forgetFinished(command.id)
       return { type: 'tasks.runs.delete' }
-    case 'tasks.running': {
-      const mapFinished = (r: ReturnType<typeof listFinished>[number]) => ({
-        runId: r.runId,
-        taskId: r.taskId,
-        label: r.label,
-        source: r.source,
-        startedAt: r.startedAt,
-        finishedAt: r.finishedAt,
-        outcome: r.outcome,
-        summary: r.summary,
-        steps: r.steps,
-      })
-      return {
-        type: 'tasks.running',
-        runs: listRunning().map((r) => ({
-          runId: r.runId,
-          taskId: r.taskId,
-          label: r.label,
-          source: r.source,
-          startedAt: r.startedAt,
-          steps: r.steps,
-        })),
-        finished: listFinished().map(mapFinished),
-      }
-    }
+    case 'tasks.running':
+      return { type: 'tasks.running', ...runningBoardsView() }
     case 'tasks.cancel':
       return { type: 'tasks.cancel', ok: cancelRun(command.runId) }
     case 'tasks.finished.delete':
@@ -466,6 +576,40 @@ async function handleCommand(command: Command): Promise<CommandResult> {
           message: error instanceof Error ? error.message : String(error),
         }
       }
+    }
+
+    case 'workflows.list':
+      return { type: 'workflows.list', workflows: await listWorkflows() }
+
+    case 'workflows.get':
+      return { type: 'workflows.get', workflow: await getWorkflow(command.id) }
+
+    case 'workflows.save':
+      await saveWorkflow(command.workflow)
+      return { type: 'workflows.save' }
+
+    case 'workflows.delete':
+      await deleteWorkflow(command.id)
+      return { type: 'workflows.delete' }
+
+    case 'workflows.run': {
+      const workflow = await getWorkflow(command.id)
+      if (!workflow) throw new Error('Workflow not found.')
+      const r = await executeWorkflow(workflow, { source: 'manual' })
+      return {
+        type: 'workflows.run',
+        outcome: {
+          ok: r.outcome === 'ok',
+          skipped: false,
+          summary: r.summary ?? '',
+          error: r.outcome === 'failed' ? r.summary : undefined,
+        },
+      }
+    }
+
+    case 'workflows.running': {
+      const boards = runningBoardsView()
+      return { type: 'workflows.running', ...boards }
     }
 
     default: {
@@ -663,6 +807,33 @@ chrome.runtime.onConnect.addListener((port) => {
         history.push({ role: 'user', content: text })
         // Persist metadata so the conversation appears in the history list.
         await touchConversation(conversationId, message.text)
+
+        // Slash-command interception: `/run <workflow>` executes a saved
+        // workflow directly instead of feeding the message to the model. On a
+        // match we report the outcome and finish the turn before `runAgentTurn`
+        // runs; the surrounding try/finally still persists the conversation and
+        // finishes the tracked run exactly once.
+        const runMatch = /^\/run\s+(.+)$/.exec(message.text.trim())
+        if (runMatch) {
+          const nameOrId = runMatch[1]!.trim()
+          const wf = (await listWorkflows()).find(
+            (w) => w.id === nameOrId || w.name.toLowerCase() === nameOrId.toLowerCase(),
+          )
+          if (!wf) {
+            throw new Error(`工作流不存在：${nameOrId}`)
+          }
+          sendWithTracking({ type: 'phase', phase: 'sending' })
+          const result = await executeWorkflow(wf, { source: 'chat' })
+          if (result.outcome === 'ok') {
+            sendWithTracking({ type: 'status', text: result.summary || `工作流「${wf.name}」执行完成。` })
+          } else if (result.outcome === 'cancelled') {
+            sendWithTracking({ type: 'status', text: '工作流已终止。' })
+          } else {
+            sendWithTracking({ type: 'error', message: result.summary || '工作流执行失败。' })
+          }
+          sendWithTracking({ type: 'done' })
+          return
+        }
 
         // The mode is read freshly per action (see AgentDeps.getMode), so a
         // switch in the panel takes effect on the next tool call within the

--- a/src/background/running-tasks.ts
+++ b/src/background/running-tasks.ts
@@ -66,6 +66,12 @@ export interface FinishedTask {
   outcome: RunOutcomeKind
   /** Final one-line summary or error, when available. */
   summary?: string
+  /**
+   * Full error text for a failed run, when the engine produced one. The
+   * one-line summary is used for the board chip; this is what the history
+   * view shows in the error block.
+   */
+  error?: string
   steps: RunStep[]
 }
 
@@ -152,6 +158,8 @@ export function setOnCancel(runId: string, onCancel: () => void): void {
 export interface FinishOptions {
   outcome: RunOutcomeKind
   summary?: string
+  /** Full error text for a failed run; surfaced in the run history. */
+  error?: string
 }
 
 /**
@@ -171,6 +179,7 @@ export function finishRun(runId: string, options?: FinishOptions): void {
     finishedAt: Date.now(),
     outcome: options?.outcome ?? (task.controller.signal.aborted ? 'cancelled' : 'ok'),
     summary: options?.summary,
+    ...(options?.error ? { error: options.error } : {}),
     steps: task.steps,
   }
   finished.unshift(entry)

--- a/src/background/scheduler.ts
+++ b/src/background/scheduler.ts
@@ -11,27 +11,43 @@
  *
  * ## Alarm name contract
  *
- * Alarm names are `task:<id>`. On startup we reconcile alarms with stored tasks:
- * tasks without an alarm get one, and stale alarms (deleted tasks) are cleared.
- * This is idempotent, so calling `rescheduleAll` after every change is safe.
+ * Alarm names are `task:<id>`, and `workflow:<id>` for workflow-kind tasks. On
+ * startup we reconcile alarms with stored tasks: tasks without an alarm get one,
+ * and stale alarms (deleted tasks) are cleared. This is idempotent, so calling
+ * `rescheduleAll` after every change is safe.
  *
  * @module background/scheduler
  */
 
 import { nextRunAt } from '../lib/schedule'
 import { getTask, listTasks, saveTask } from '../lib/task-store'
+import type { ScheduledTask } from '../lib/scheduler-types'
 import { runTask } from './task-runner'
 
 const ALARM_PREFIX = 'task:'
+const WORKFLOW_ALARM_PREFIX = 'workflow:'
 /** `chrome.alarms` rejects periods and delays under 1 minute. */
 const MIN_ALARM_DELAY_MS = 60_000
 
+/** Legacy name for a task alarm; workflow-kind tasks use the `workflow:` prefix. */
 function alarmName(taskId: string): string {
   return `${ALARM_PREFIX}${taskId}`
 }
 
+/**
+ * Alarm name for a specific task, chosen by its kind so workflow tasks can be
+ * told apart (and orphan-cleared) independently from plain scheduled tasks.
+ */
+function alarmNameFor(task: ScheduledTask): string {
+  return task.kind === 'workflow'
+    ? `${WORKFLOW_ALARM_PREFIX}${task.id}`
+    : `${ALARM_PREFIX}${task.id}`
+}
+
 export function taskIdFromAlarmName(name: string): string | null {
-  return name.startsWith(ALARM_PREFIX) ? name.slice(ALARM_PREFIX.length) : null
+  if (name.startsWith(WORKFLOW_ALARM_PREFIX)) return name.slice(WORKFLOW_ALARM_PREFIX.length)
+  if (name.startsWith(ALARM_PREFIX)) return name.slice(ALARM_PREFIX.length)
+  return null
 }
 
 /**
@@ -40,7 +56,9 @@ export function taskIdFromAlarmName(name: string): string | null {
  */
 export async function scheduleTask(taskId: string): Promise<void> {
   const task = await getTask(taskId)
-  const name = alarmName(taskId)
+  // Fall back to the legacy `task:` prefix when the task cannot be found, so a
+  // deleted task's alarm is still cleared by the caller's reschedule.
+  const name = task ? alarmNameFor(task) : alarmName(taskId)
   if (!task || !task.enabled) {
     await chrome.alarms.clear(name)
     return
@@ -55,13 +73,18 @@ export async function scheduleTask(taskId: string): Promise<void> {
 /** Clears and recreates alarms for every task, removing orphaned alarms. */
 export async function rescheduleAll(): Promise<void> {
   // Clear anything that no longer corresponds to a known, enabled task first, so
-  // a deleted task cannot fire later.
+  // a deleted task cannot fire later. Orphaned alarms are swept for BOTH the
+  // plain-task and workflow prefixes.
   const existing = await chrome.alarms.getAll()
   const tasks = await listTasks()
-  const known = new Set(tasks.filter((task) => task.enabled).map((task) => alarmName(task.id)))
+  const known = new Set(
+    tasks.filter((task) => task.enabled).map((task) => alarmNameFor(task)),
+  )
 
   for (const alarm of existing) {
-    if (alarm.name.startsWith(ALARM_PREFIX) && !known.has(alarm.name)) {
+    const isOurs =
+      alarm.name.startsWith(ALARM_PREFIX) || alarm.name.startsWith(WORKFLOW_ALARM_PREFIX)
+    if (isOurs && !known.has(alarm.name)) {
       await chrome.alarms.clear(alarm.name)
     }
   }

--- a/src/background/task-runner.ts
+++ b/src/background/task-runner.ts
@@ -25,6 +25,8 @@ import {
 } from '../lib/task-store'
 import { runUnattendedPrompt } from './agent-unattended'
 import { retain, release } from './keepalive'
+import { getWorkflow } from '../lib/workflow/storage'
+import { executeWorkflow } from './workflow-engine/run-workflow'
 import {
   addStep,
   finishRun,
@@ -93,6 +95,7 @@ export async function runTask(
     finishRun(tracked.runId, {
       outcome: boardOutcome,
       summary: outcome.summary?.split('\n')[0] || outcome.error,
+      ...(outcome.error ? { error: outcome.error } : {}),
     })
   }
 
@@ -128,6 +131,8 @@ async function executeTask(
       return runReviewRequests(lang, tracked)
     case 'agent-prompt':
       return runAgentPrompt(task, lang, tracked)
+    case 'workflow':
+      return runWorkflowTask(task, tracked)
     default: {
       // Exhaustiveness guard: a future task kind that isn't wired up fails
       // loudly rather than silently doing nothing. Cast through string so this
@@ -195,6 +200,34 @@ async function runAgentPrompt(task: ScheduledTask, _lang: string, tracked: Runni
     summary: result.answer,
     error: result.error,
     cancelled: result.cancelled,
+  }
+}
+
+/**
+ * Runs a scheduled workflow-kind task through the workflow engine. The engine
+ * already maps its steps onto the tracked run (see `executeWorkflow`), so this
+ * only needs to look the stored workflow up and translate the settling outcome.
+ */
+async function runWorkflowTask(task: ScheduledTask, tracked: RunningTask): Promise<RunOutcome> {
+  const workflow = task.workflowId ? await getWorkflow(task.workflowId) : undefined
+  if (!workflow) {
+    return { ok: false, skipped: false, summary: '', error: 'This task has no workflow.' }
+  }
+  addStep(tracked.runId, 'info', `Running workflow: ${workflow.name}`)
+  const outcome = await executeWorkflow(workflow, {
+    source: 'schedule',
+    taskId: task.id,
+    feishuChatId: tracked.feishuChatId,
+  })
+  return {
+    ok: outcome.outcome === 'ok',
+    skipped: false,
+    summary: outcome.summary ?? '',
+    error:
+      outcome.outcome === 'failed'
+        ? (outcome.error ?? outcome.summary)
+        : undefined,
+    cancelled: outcome.outcome === 'cancelled',
   }
 }
 

--- a/src/background/workflow-engine/engine.ts
+++ b/src/background/workflow-engine/engine.ts
@@ -1,0 +1,430 @@
+/**
+ * Workflow execution engine.
+ *
+ * A pure, chrome-free interpreter that walks a `Workflow` graph, dispatching
+ * each node's block label to its executor in {@link EXECUTORS}. Keeping this
+ * layer free of any `chrome` / storage / running-task coupling makes the
+ * routing, branching, cancellation and loop-guard logic directly unit-testable.
+ *
+ * @module background/workflow-engine/engine
+ */
+
+import type { Workflow, WorkflowEdge, WorkflowNode } from '../../lib/workflow/types'
+import { getWorkflow } from '../../lib/workflow/storage'
+import {
+  EXECUTORS,
+  type BlockExecutor,
+  type WorkflowExecCtx,
+} from './executors'
+
+export type EmitKind = 'status' | 'result' | 'error' | 'info'
+
+export interface WorkflowRunOptions {
+  /** Node id to start from. Defaults to the first trigger or, failing that, the first node. */
+  startAt?: string
+  /** Initial runtime variables. */
+  variables?: Record<string, unknown>
+  /** Shared abort signal; aborting requests a `'cancelled'` outcome. */
+  signal?: AbortSignal
+  /** Called for every status/result/error/info a block emits, plus engine errors. */
+  onStep?(kind: EmitKind, nodeId: string, text: string): void
+  /** Override / inject the block-executor map (falls back to {@link EXECUTORS}). */
+  executors?: Partial<Record<string, BlockExecutor>>
+  /**
+   * Workflow ids already on the `execute-workflow` call stack, used to guard
+   * against a→a self-loops. Filled in by recursive `runCore` calls.
+   */
+  parentWorkflowIds?: Set<string>
+  /**
+   * Resolves how many page elements a `loop-elements` block should iterate.
+   * Injected by the integration layer so the pure engine stays chrome-free; in
+   * tests a stub or a literal `count` value in the node data may be used.
+   */
+  loopElementCounter?: (cssSelector: string, signal: AbortSignal) => number | Promise<number>
+}
+
+export interface WorkflowRunResult {
+  outcome: 'ok' | 'cancelled' | 'failed'
+  completedNodeIds: string[]
+  summary?: string
+  /** Full failure detail when outcome is 'failed'; may be multi-line. */
+  error?: string
+}
+
+/** Guards against infinite/long loops in mis-wired graphs. */
+const MAX_STEPS = 2000
+
+/** Guards a `while-loop` whose body never progresses toward a false condition. */
+const MAX_WHILE_ITERATIONS = 1000
+
+/** Block ids that represent launch triggers; used to pick a start node. */
+const TRIGGER_BLOCK_IDS = new Set([
+  'manual',
+  'schedule',
+  'scheduled',
+  'visit-web',
+  'context-menu',
+  'on-startup',
+  'keyboard-shortcut',
+  'date',
+  'specific-day',
+  'element-change',
+])
+
+/**
+ * Resolve the canonical block id for a node. Newer workflows store it under
+ * `data.blockId`; legacy nodes only have `label` (which was once the English
+ * block id and later became the localized display name). Fall back in that
+ * order so old saved graphs still dispatch, and so a Chinese display label
+ * never reaches the executor registry.
+ */
+function blockIdOf(node: WorkflowNode): string {
+  const fromData = node.data?.['blockId']
+  if (typeof fromData === 'string' && fromData) return fromData
+  return node.label
+}
+
+/**
+ * Resolve the parameter bag for a block. The editor persists user-entered
+ * values under `data.values`; some legacy / programmatically-built graphs
+ * store params directly on `data`. We prefer `values` when present so
+ * executors can keep reading `data['url']` etc. without knowing the layout.
+ */
+function paramsOf(node: WorkflowNode): Record<string, unknown> {
+  const values = node.data?.['values']
+  if (values && typeof values === 'object' && !Array.isArray(values)) {
+    return values as Record<string, unknown>
+  }
+  return node.data ?? {}
+}
+
+/**
+ * Loop blocks the engine interprets directly (they recurse through their body
+ * via {@link runSegment}, exactly like `loop-data`). An executor cannot drive a
+ * loop body because it returns a single next-node id, so the loop semantics
+ * live here in the interpreter. Keyed by block id.
+ */
+const LOOP_BLOCK_IDS = new Set(['loop-data', 'repeat-task', 'while-loop', 'loop-elements'])
+
+const CANCELLED_SUMMARY = '运行已取消'
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/** Evaluates a `while-loop` condition expression against the run's variables. */
+function evalLoopCondition(code: string, vars: Record<string, unknown>): boolean {
+  try {
+    const test = new Function('vars', 'refData', `return (${code})`)
+    return Boolean(test(vars, undefined))
+  } catch {
+    return false
+  }
+}
+
+function isAbort(error: unknown): boolean {
+  return (
+    error instanceof DOMException
+      ? error.name === 'AbortError'
+      : (error as { name?: string }).name === 'AbortError'
+  )
+}
+
+/**
+ * Export the default ref data value so run layers can opt out of it. The pure
+ * engine has no table row, so refData is `undefined` unless the caller mutates
+ * the shared context afterwards (engines do not persist across blocks beyond
+ * `variables`).
+ */
+function buildExecCtx(
+  variables: Record<string, unknown>,
+  signal: AbortSignal,
+  currentId: string,
+  outputs: Record<string, string>,
+  defaultNext: string | null,
+  onStep: (kind: EmitKind, nodeId: string, text: string) => void,
+): WorkflowExecCtx {
+  return {
+    variables,
+    refData: undefined,
+    signal,
+    outputs,
+    defaultNext,
+    emit: (kind, text) => onStep(kind, currentId, text),
+  }
+}
+
+/**
+ * Run a workflow to completion (or cancellation / failure).
+ *
+ * Pure and dependency-free so tests can exercise routing, branching, abort and
+ * loop-guard behaviour without mocking `chrome`.
+ */
+export async function runWorkflow(
+  workflow: Workflow,
+  options: WorkflowRunOptions = {},
+): Promise<WorkflowRunResult> {
+  return runCore(workflow, options)
+}
+
+/** Sentinel returned by the loop body runner when it reaches the loop node. */
+const LOOP_EXIT = '\u0000loop-exit'
+
+/**
+ * Internal interpreter shared by the top-level entry point and recursive
+ * `execute-workflow` runs. The loop body and sub-workflow both reuse the same
+ * node-walking logic so steps are counted against one shared MAX_STEPS.
+ */
+async function runCore(
+  workflow: Workflow,
+  options: WorkflowRunOptions,
+): Promise<WorkflowRunResult> {
+  const {
+    startAt,
+    variables = {},
+    signal,
+    onStep,
+    executors = EXECUTORS,
+    parentWorkflowIds = new Set<string>(),
+    loopElementCounter,
+  } = options
+
+  const nodes = workflow.drawflow.nodes
+  const edges = workflow.drawflow.edges
+  const nodeById = new Map(nodes.map((n) => [n.id, n]))
+
+  const outBySource = new Map<string, WorkflowEdge[]>()
+  for (const edge of edges) {
+    const list = outBySource.get(edge.source)
+    if (list) list.push(edge)
+    else outBySource.set(edge.source, [edge])
+  }
+
+  const emit = (kind: EmitKind, nodeId: string, text: string) => onStep?.(kind, nodeId, text)
+  const signalToUse = signal ?? new AbortController().signal
+
+  const completedNodeIds: string[] = []
+  let outcome: WorkflowRunResult['outcome'] = 'ok'
+  let summary: string | undefined
+  let error: string | undefined
+  let steps = 0
+  let currentNodeId = ''
+
+  /** Run exactly one node; returns the next node id or `null` to finish. */
+  async function runNode(nodeId: string): Promise<string | null> {
+    if (signalToUse.aborted) throw new DOMException('Aborted', 'AbortError')
+
+    const current = nodeById.get(nodeId)
+    if (!current) return null
+    currentNodeId = nodeId
+
+    if (++steps > MAX_STEPS) {
+      emit('error', nodeId, '步骤超限，疑似死循环')
+      outcome = 'failed'
+      error = '步骤超限，疑似死循环'
+      return null
+    }
+
+    const outEdges = outBySource.get(nodeId) ?? []
+    const outputs: Record<string, string> = {}
+    for (const edge of outEdges) outputs[edge.sourceHandle ?? 'next'] = edge.target
+    const defaultNext = outEdges[0]?.target ?? null
+
+    const blockId = blockIdOf(current)
+    const params = paramsOf(current)
+
+    // Loop and sub-workflow blocks are handled by the engine itself, not by an
+    // executor in the registry, so sub-runs and loop bodies recurse here too.
+    if (LOOP_BLOCK_IDS.has(blockId)) {
+      completedNodeIds.push(nodeId)
+      return runLoop(current, params, defaultNext)
+    }
+    if (blockId === 'execute-workflow') {
+      completedNodeIds.push(nodeId)
+      return runSubWorkflow(current, params, defaultNext)
+    }
+
+    const executor = executors[blockId]
+    if (!executor) {
+      const text = `没有找到块执行器: ${blockId}`
+      emit('error', nodeId, text)
+      outcome = 'failed'
+      error = text
+      return null
+    }
+
+    const ctx = buildExecCtx(variables, signalToUse, nodeId, outputs, defaultNext, emit)
+    let resolver: string | null | undefined
+    try {
+      resolver = await executor(params, ctx)
+    } catch (e) {
+      const text = message(e)
+      emit('error', nodeId, text)
+      if (isAbort(e)) {
+        outcome = 'cancelled'
+        summary = CANCELLED_SUMMARY
+      } else {
+        outcome = 'failed'
+        error = text
+      }
+      return null
+    }
+
+    const nextResult = resolver ?? defaultNext
+    completedNodeIds.push(nodeId)
+    return nextResult
+  }
+
+  /**
+   * Walk from `startId`, dispatching nodes, until the flow ends (null) or — when
+   * a `stopAt` is given (the enclosing loop node) — the flow routes back to it.
+   */
+  async function runSegment(startId: string, stopAt?: string): Promise<string | null> {
+    let currentId: string | null = startId
+    while (currentId) {
+      const next = await runNode(currentId)
+      if (next === null) return null
+      if (stopAt !== undefined && next === stopAt) return LOOP_EXIT
+      currentId = next
+    }
+    return null
+  }
+
+  /**
+   * Runs the body of a loop block once per iteration, dispatching on the loop
+   * block's label:
+   * - `loop-data`: once per parsed JSON array item (exposes loopIndex/loopItem)
+   * - `repeat-task`: a fixed number of times
+   * - `while-loop`: until its `code` expression evaluates to false
+   * - `loop-elements`: once per page element matched (exposes loopIndex)
+   */
+  async function runLoop(
+    loopNode: WorkflowNode,
+    params: Record<string, unknown>,
+    startId: string | null,
+  ): Promise<string | null> {
+    const label = blockIdOf(loopNode)
+
+    if (label === 'loop-data') {
+      let items: unknown[] = []
+      try {
+        const parsed = JSON.parse(String(params['data'] ?? '[]'))
+        if (Array.isArray(parsed)) items = parsed
+      } catch {
+        emit('error', loopNode.id, 'loop-data: 数据解析失败')
+        return null
+      }
+      emit('status', loopNode.id, `开始循环，共 ${items.length} 项`)
+      if (startId === null) return null
+      for (let i = 0; i < items.length; i++) {
+        if (signalToUse.aborted) throw new DOMException('Aborted', 'AbortError')
+        variables['loopIndex'] = i
+        variables['loopItem'] = items[i]
+        await runSegment(startId, loopNode.id)
+        if (outcome !== 'ok') return null
+      }
+      return null
+    }
+
+    if (label === 'repeat-task') {
+      const count = Math.max(0, Number(params['count'] ?? 1))
+      emit('status', loopNode.id, `重复执行 ${count} 次`)
+      if (startId === null) return null
+      for (let i = 0; i < count; i++) {
+        if (signalToUse.aborted) throw new DOMException('Aborted', 'AbortError')
+        variables['loopIndex'] = i
+        await runSegment(startId, loopNode.id)
+        if (outcome !== 'ok') return null
+      }
+      return null
+    }
+
+    if (label === 'while-loop') {
+      const code = String(params['code'] ?? 'false')
+      if (startId === null) return null
+      let iterations = 0
+      while (evalLoopCondition(code, variables)) {
+        if (signalToUse.aborted) throw new DOMException('Aborted', 'AbortError')
+        variables['loopIndex'] = iterations
+        await runSegment(startId, loopNode.id)
+        if (outcome !== 'ok') return null
+        if (++iterations > MAX_WHILE_ITERATIONS) {
+          const text = 'while-loop: 迭代超限，疑似死循环'
+          emit('error', loopNode.id, text)
+          outcome = 'failed'
+          error = text
+          return null
+        }
+      }
+      return null
+    }
+
+    // loop-elements
+    const selector = String(params['cssSelector'] ?? '')
+    let count = 0
+    if (loopElementCounter) {
+      count = await loopElementCounter(selector, signalToUse)
+    } else {
+      // Non-browser contexts (pure engine tests) fall back to a literal count.
+      count = Math.max(0, Number(params['count'] ?? 0))
+    }
+    emit('status', loopNode.id, `遍历 ${count} 个元素`)
+    if (startId === null) return null
+    for (let i = 0; i < count; i++) {
+      if (signalToUse.aborted) throw new DOMException('Aborted', 'AbortError')
+      variables['loopIndex'] = i
+      await runSegment(startId, loopNode.id)
+      if (outcome !== 'ok') return null
+    }
+    return null
+  }
+
+  /** Executes a referenced workflow as a nested run, then follows the edge. */
+  async function runSubWorkflow(
+    execNode: WorkflowNode,
+    params: Record<string, unknown>,
+    defaultNext: string | null,
+  ): Promise<string | null> {
+    const childId = String(params['workflowId'] ?? '')
+    if (parentWorkflowIds.has(childId)) {
+      emit('error', execNode.id, `execute-workflow: 检测到工作流自循环 ${childId}`)
+      return defaultNext
+    }
+    const child = await getWorkflow(childId)
+    if (!child) {
+      emit('error', execNode.id, `execute-workflow: 未找到工作流 ${childId}`)
+      return defaultNext
+    }
+
+    const childStack = new Set(parentWorkflowIds)
+    childStack.add(childId)
+    await runCore(child, {
+      variables,
+      signal: signalToUse,
+      executors,
+      parentWorkflowIds: childStack,
+      onStep: onStep ? (kind, nodeId, text) => onStep(kind, nodeId, `[子] ${text}`) : undefined,
+    })
+    return defaultNext
+  }
+
+  try {
+    let startId = startAt
+    if (!startId) startId = nodes.find((n) => TRIGGER_BLOCK_IDS.has(blockIdOf(n)))?.id
+    if (!startId) startId = nodes[0]?.id
+    if (startId) await runSegment(startId)
+  } catch (e) {
+    // Top-of-loop abort check (or an unexpected engine error) surfaced here.
+    const text = message(e)
+    emit('error', currentNodeId, text)
+    if (isAbort(e)) {
+      outcome = 'cancelled'
+      summary = CANCELLED_SUMMARY
+    } else {
+      outcome = 'failed'
+      error = text
+    }
+  }
+
+  return { outcome, completedNodeIds, summary, ...(error ? { error } : {}) }
+}

--- a/src/background/workflow-engine/executors.ts
+++ b/src/background/workflow-engine/executors.ts
@@ -1,0 +1,1124 @@
+/**
+ * Workflow block executors — the browser-class implementations.
+ *
+ * The engine contract: each block is an async function that receives the
+ * node's `data` plus an execution context, and returns the id of the next node
+ * to run (or `null` to let the engine follow the default single out-edge).
+ *
+ * Browser-class executors reuse `lib/ops` + `background/driver` instead of
+ * re-implementing DOM logic. Non-browser blocks (data / control-flow /
+ * integration / trigger) are registered as placeholders until phase 4 fills
+ * them in.
+ *
+ * @module background/workflow-engine/executors
+ */
+
+import { isInjectablePage } from '../../lib/pages'
+import { streamCompletion, type WireMessage } from '../../lib/llm'
+import { getSettings } from '../../lib/storage'
+import { interpolate } from '../../lib/workflow/interpolate'
+import type { Op, ScrollSpec, Target } from '../../lib/ops'
+import { activeTab } from '../page'
+import {
+  clipboardGet,
+  clipboardInsert,
+  closeActiveTab,
+  cookieGet,
+  cookieGetAll,
+  cookieRemove,
+  cookieSet,
+  elementExists,
+  execOnActiveTab,
+  getActiveTabInfo,
+  goBack,
+  goForward,
+  listAllTabUrls,
+  newTab as driverNewTab,
+  newWindow as driverNewWindow,
+  switchTab as driverSwitchTab,
+} from '../driver'
+
+/** Execution context handed to every block executor. */
+export interface WorkflowExecCtx {
+  /** Mutable variable storage, keyed by variable name. */
+  variables: Record<string, unknown>
+  /** The data-table current row (if table-backed). */
+  refData: unknown
+  signal: AbortSignal
+  emit(kind: 'status' | 'result' | 'error' | 'info', text: string): void
+  /**
+   * The current block's output handles → target node ids, so branch blocks
+   * (e.g. `condition`) can route to a specific edge by its handle id. The
+   * default single out-edge is keyed as `'next'`.
+   */
+  outputs?: Record<string, string>
+  /** The default out-edge target node id; used when the executor returns null. */
+  defaultNext?: string | null
+}
+
+/**
+ * A block execution step. Returns the next node id to route to (for explicit
+ * selection like conditions); `null` means "follow the default single edge".
+ */
+export type BlockExecutor = (
+  data: Record<string, unknown>,
+  ctx: WorkflowExecCtx,
+) => Promise<string | null>
+
+// --- Helpers -----------------------------------------------------------------
+
+/** Read the required `cssSelector` param off a block's data. */
+function sel(data: Record<string, unknown>): string {
+  return data['cssSelector'] as string
+}
+
+/** Build a CSS-only `Target` for the driver. */
+function cssTarget(selector: string): Target {
+  return { primary: { how: 'css', value: selector }, fallbacks: [] }
+}
+
+/** Abort fast when the run was cancelled before this step started. */
+function assertActive(ctx: WorkflowExecCtx): void {
+  if (ctx.signal.aborted) throw new DOMException('Aborted', 'AbortError')
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * Run one op on the active tab and report the outcome. A thrown error is
+ * emitted (not swallowed) and the engine continues on the default edge.
+ */
+async function runRaw(op: Op, ctx: WorkflowExecCtx): Promise<string | null> {
+  assertActive(ctx)
+  try {
+    const result = await execOnActiveTab(op, ctx.signal)
+    ctx.emit('result', result?.note ?? 'ok')
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+/** Top-level injected function for the `get-text` block. No closure. */
+function readTextInPage(selector: string): string {
+  const el = document.querySelector(selector)
+  return el ? (el.textContent ?? '').trim() : ''
+}
+
+// --- Browser executors -------------------------------------------------------
+
+const click: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  return runRaw({ action: 'click', target: cssTarget(sel(data)) }, ctx)
+}
+
+const fill: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const value = String(data['value'] ?? '')
+  return runRaw({ action: 'fill', target: cssTarget(sel(data)), value }, ctx)
+}
+
+const selectOption: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const value = String(data['value'] ?? '')
+  return runRaw({ action: 'select_option', target: cssTarget(sel(data)), value }, ctx)
+}
+
+const scroll: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const mode = (data['mode'] as string | undefined) ?? 'into_view'
+  const smooth = (data['scrollBehavior'] as string | undefined) === 'smooth'
+  const x = Number(data['x'] ?? 0)
+  const y = Number(data['y'] ?? 0)
+  let scroll: ScrollSpec
+  if (mode === 'by') scroll = { mode: 'by', x, y, smooth }
+  else if (mode === 'incremental') scroll = { mode: 'incremental', x, y }
+  else if (mode === 'top') scroll = { mode: 'top', smooth }
+  else if (mode === 'bottom') scroll = { mode: 'bottom', smooth }
+  else scroll = { mode: 'into_view' }
+
+  const selector = (data['cssSelector'] as string | undefined) ?? ''
+  const op: Op = { action: 'scroll', scroll }
+  if (selector) op.target = cssTarget(selector)
+
+  // Incremental scroll = split the delta into small repeated steps so the page
+  // scrolls a section at a time instead of one big jump.
+  if (mode === 'incremental') {
+    const step = Math.max(1, Number(data['step'] ?? 120))
+    const steps = Math.max(1, Math.ceil(Math.max(Math.abs(x), Math.abs(y)) / step))
+    for (let i = 0; i < steps; i += 1) {
+      assertActive(ctx)
+      const safe = { ...op, scroll: { mode: 'by' as const, x: x / steps, y: y / steps, smooth: true } }
+      try {
+        await execOnActiveTab(safe, ctx.signal)
+      } catch (error) {
+        ctx.emit('error', message(error))
+        break
+      }
+    }
+    ctx.emit('result', `增量滚动完成`)
+    return null
+  }
+
+  return runRaw(op, ctx)
+}
+
+const pressKey: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const key = String(data['key'] ?? '')
+  ctx.emit('status', `按下按键: ${key}`)
+  return runRaw({ action: 'press_key', value: key }, ctx)
+}
+
+const hover: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  return runRaw({ action: 'hover', target: cssTarget(sel(data)) }, ctx)
+}
+
+const setCheckbox: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const checked = (data['checked'] as boolean | undefined) ?? true
+  return runRaw({ action: 'set_checkbox', target: cssTarget(sel(data)), value: checked }, ctx)
+}
+
+const waitFor: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  try {
+    const result = await execOnActiveTab(
+      { action: 'wait_for', target: cssTarget(sel(data)) },
+      ctx.signal,
+    )
+    if (result?.found) ctx.emit('result', '元素已出现')
+    else ctx.emit('error', '等待超时，元素未出现')
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const takeScreenshot: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const type = (data['type'] as string | undefined) ?? 'page'
+  const selector = (data['cssSelector'] as string | undefined) ?? ''
+  const variable = String(data['variableName'] ?? 'lastScreenshot')
+
+  // fullpage / element go through the in-page SVG->canvas capture path.
+  if (type === 'fullpage' || type === 'element') {
+    try {
+      const op: Op = { action: 'capture' }
+      if (type === 'element') {
+        if (!selector) {
+          ctx.emit('error', '元素截图需要 CSS 选择器')
+          return null
+        }
+        op.value = selector
+      }
+      const result = await execOnActiveTab(op, ctx.signal)
+      if (result.ok && typeof result.data === 'string') {
+        ctx.variables[variable] = result.data
+        ctx.emit('result', `已截图 (${type})`)
+      } else {
+        ctx.emit('error', result.error ?? '截图失败')
+      }
+    } catch (error) {
+      ctx.emit('error', message(error))
+    }
+    return null
+  }
+
+  // Default: visible page snapshot.
+  const tab = await activeTab()
+  if (!tab || typeof tab.id !== 'number') {
+    ctx.emit('error', '没有可截图的活动标签页')
+    return null
+  }
+  try {
+    const dataUrl = await chrome.tabs.captureVisibleTab(tab.windowId, { format: 'png' })
+    ctx.variables[variable] = dataUrl
+    ctx.emit('result', '已截图')
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const getText: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const selector = sel(data)
+  const tab = await activeTab()
+  if (!tab || typeof tab.id !== 'number') {
+    ctx.emit('error', '没有活动标签页')
+    return null
+  }
+  const [injection] = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: readTextInPage,
+    args: [selector],
+  })
+  const text = (injection?.result as string | undefined) ?? ''
+  ctx.variables['lastText'] = text
+  ctx.emit('result', text)
+  return null
+}
+
+// --- Navigation executors ----------------------------------------------------
+
+const openUrl: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const url = String(data['url'] ?? '')
+  if (!isInjectablePage(url)) {
+    ctx.emit('error', `仅允许打开 http(s) 页面: ${url}`)
+    return null
+  }
+  const tab = await activeTab()
+  if (!tab || typeof tab.id !== 'number') {
+    ctx.emit('error', '没有活动标签页')
+    return null
+  }
+  await chrome.tabs.update(tab.id, { url })
+  ctx.emit('result', `已打开 ${url}`)
+  return null
+}
+
+const newTabExec: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const url = data['url'] ? String(data['url']) : undefined
+  try {
+    const tab = await driverNewTab(url)
+    ctx.emit('result', `已新建标签页 #${tab.id}`)
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const switchTabExec: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  try {
+    const tab = await driverSwitchTab(Number(data['index'] ?? 0))
+    ctx.emit('result', `已切换到标签页 #${tab.id}`)
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const closeTabExec: BlockExecutor = async (_data, ctx) => {
+  assertActive(ctx)
+  try {
+    await closeActiveTab()
+    ctx.emit('result', '已关闭当前标签页')
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const reloadTabExec: BlockExecutor = async (_data, ctx) => {
+  assertActive(ctx)
+  const tab = await activeTab()
+  if (!tab || typeof tab.id !== 'number') {
+    ctx.emit('error', '没有活动标签页')
+    return null
+  }
+  await chrome.tabs.reload(tab.id)
+  ctx.emit('result', '已刷新当前标签页')
+  return null
+}
+
+// --- Data / control-flow / integration executors -----------------------------
+
+/** Resolve `ms` with abort support, so cancellation wakes a sleeping delay. */
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'))
+      return
+    }
+    const timer = setTimeout(resolve, ms)
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer)
+        reject(new DOMException('Aborted', 'AbortError'))
+      },
+      { once: true },
+    )
+  })
+}
+
+const setVariable: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const name = String(data['variableName'] ?? '')
+  const value = interpolate(String(data['value'] ?? ''), ctx.variables, ctx.refData)
+  ctx.variables[name] = value
+  ctx.emit('result', `已设置变量 ${name}`)
+  return null
+}
+
+const getVariable: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const value = ctx.variables[String(data['variableName'] ?? '')]
+  ctx.variables['lastValue'] = value
+  ctx.emit('result', String(value ?? ''))
+  return null
+}
+
+const insertData: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  let items: unknown[] = []
+  try {
+    const parsed = JSON.parse(String(data['data'] ?? '[]'))
+    if (Array.isArray(parsed)) items = parsed
+  } catch {
+    /* malformed json → insert nothing */
+  }
+  if (!Array.isArray(ctx.variables['dataTable'])) ctx.variables['dataTable'] = []
+  const table = ctx.variables['dataTable'] as unknown[]
+  table.push(...items)
+  ctx.emit('result', `已插入 ${items.length} 行`)
+  return null
+}
+
+const exportData: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const table = Array.isArray(ctx.variables['dataTable'])
+    ? (ctx.variables['dataTable'] as Record<string, unknown>[])
+    : Array.isArray(ctx.refData)
+      ? (ctx.refData as Record<string, unknown>[])
+      : []
+  const format = String(data['format'] ?? 'csv')
+  let text = ''
+  if (format === 'json') {
+    text = JSON.stringify(table)
+  } else if (table.length === 0) {
+    text = ''
+  } else {
+    const header = Object.keys(table[0] as Record<string, unknown>)
+    const cell = (value: unknown): string => {
+      const raw = String(value ?? '')
+      return /[",\n]/.test(raw) ? `"${raw.replace(/"/g, '""')}"` : raw
+    }
+    const rows = [header, ...table.map((row) => header.map((key) => cell(row[key])))]
+    text = rows.map((row) => row.join(',')).join('\n')
+  }
+  ctx.variables['lastExport'] = text
+  ctx.emit('result', text.slice(0, 80))
+  return null
+}
+
+const condition: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const code = String(data['code'] ?? 'true')
+  let ok = false
+  try {
+    const test = new Function('vars', 'refData', `return (${code})`)
+    ok = Boolean(test(ctx.variables, ctx.refData))
+  } catch {
+    ctx.emit('error', '条件表达式错误')
+    ok = false
+  }
+  return ok
+    ? (ctx.outputs?.['true'] ?? ctx.defaultNext ?? null)
+    : (ctx.outputs?.['false'] ?? ctx.defaultNext ?? null)
+}
+
+const delay: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const ms = Number(data['ms'] ?? '500')
+  await sleep(ms, ctx.signal)
+  ctx.emit('status', `延时 ${ms}ms`)
+  return null
+}
+
+const breakpoint: BlockExecutor = async (_data, ctx) => {
+  assertActive(ctx)
+  ctx.emit('info', '断点：执行暂停在此处')
+  return null
+}
+
+const webhook: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const url = interpolate(String(data['url'] ?? ''), ctx.variables, ctx.refData)
+  const method = String(data['method'] ?? 'POST').toUpperCase()
+  const timeout = Math.max(0, Number(data['timeout'] ?? 30000))
+  const responseVariable = String(data['responseVariable'] ?? 'lastHttpResponse')
+
+  // Headers: interpolated JSON string, e.g. `{"Authorization":"Bearer ..."}`.
+  let headers: Record<string, string> = { 'content-type': 'application/json' }
+  const headersRaw = interpolate(String(data['headers'] ?? ''), ctx.variables, ctx.refData)
+  if (headersRaw.trim()) {
+    try {
+      const parsed = JSON.parse(headersRaw)
+      if (parsed && typeof parsed === 'object') headers = { ...headers, ...parsed } as Record<string, string>
+    } catch {
+      ctx.emit('error', 'webhook: headers 不是合法 JSON，使用默认头')
+    }
+  }
+
+  // Body: interpolated JSON (or raw text). GET/HEAD send no body.
+  let bodyText: string | undefined
+  const rawBody = interpolate(String(data['body'] ?? ''), ctx.variables, ctx.refData)
+  if (method !== 'GET' && method !== 'HEAD' && rawBody !== '') {
+    let parsed: unknown = rawBody
+    try {
+      parsed = JSON.parse(rawBody)
+    } catch {
+      /* fall back to the raw string */
+    }
+    bodyText = typeof parsed === 'string' ? parsed : JSON.stringify(parsed)
+  }
+
+  try {
+    const controller = new AbortController()
+    const onAbort = (): void => controller.abort()
+    ctx.signal.addEventListener('abort', onAbort, { once: true })
+    const timer = timeout > 0 ? setTimeout(() => controller.abort(), timeout) : undefined
+    try {
+      const response = await fetch(url, {
+        method,
+        headers,
+        body: bodyText,
+        signal: controller.signal,
+      })
+      const responseText = await response.text()
+      const record = {
+        status: response.status,
+        ok: response.ok,
+        headers: Object.fromEntries(response.headers.entries()),
+        body: responseText,
+      }
+      ctx.variables[responseVariable] = record
+      ctx.emit('result', `${method} ${response.status} ${responseText.slice(0, 80)}`)
+    } finally {
+      if (timer !== undefined) clearTimeout(timer)
+      ctx.signal.removeEventListener('abort', onAbort)
+    }
+  } catch (error) {
+    if ((error as Error)?.name !== 'AbortError') ctx.emit('error', message(error))
+    else ctx.emit('error', `${method} 请求超时或已取消`)
+  }
+  return null
+}
+
+const notification: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const title = interpolate(String(data['title'] ?? '通知'), ctx.variables, ctx.refData)
+  const body = interpolate(String(data['message'] ?? ''), ctx.variables, ctx.refData)
+  const api = typeof chrome !== 'undefined' ? chrome.notifications : undefined
+  if (api) {
+    try {
+      await api.create({ type: 'basic', iconUrl: 'icons/icon-48.png', title, message: body })
+    } catch (error) {
+      ctx.emit('error', message(error))
+    }
+  } else {
+    ctx.emit('info', '通知不可用')
+  }
+  ctx.emit('result', '已通知')
+  return null
+}
+
+const javascriptCode: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const code = String(data['code'] ?? '')
+  try {
+    const fn = new Function('vars', 'refData', 'data', `return (()=>{${code}})()`)
+    const result = fn(ctx.variables, ctx.refData, data)
+    ctx.variables['lastResult'] = result
+    ctx.emit('result', String(result ?? ''))
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const aiPrompt: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const prompt = interpolate(String(data['prompt'] ?? ''), ctx.variables, ctx.refData)
+  const settings = await getSettings()
+  const provider = settings.providers.find((p) => p.id === settings.activeProviderId)
+  if (!provider || !provider.apiKey.trim()) {
+    ctx.emit('error', 'AI 块: 未配置模型给 provider')
+    return null
+  }
+  const messages: WireMessage[] = [{ role: 'user', content: prompt }]
+  try {
+    const result = await streamCompletion({
+      apiKey: provider.apiKey,
+      baseUrl: provider.baseUrl,
+      model: provider.model,
+      messages,
+      headers: provider.headers,
+      signal: ctx.signal,
+    })
+    ctx.variables['lastAIResponse'] = result.content
+    ctx.emit('result', result.content)
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+/** Launch triggers act as pass-through entry points in the browser build. */
+const noop: BlockExecutor = async () => Promise.resolve(null)
+
+// --- Phase 2: browser actions ----------------------------------------------
+
+const cookieBlock: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const op = String(data['op'] ?? 'get')
+  const name = interpolate(String(data['name'] ?? ''), ctx.variables, ctx.refData)
+  const value = interpolate(String(data['value'] ?? ''), ctx.variables, ctx.refData)
+  const url = interpolate(String(data['url'] ?? ''), ctx.variables, ctx.refData)
+  const variable = String(data['variableName'] ?? 'lastCookie')
+  try {
+    if (op === 'getAll') {
+      const cookies = await cookieGetAll(url || undefined)
+      ctx.variables[variable] = cookies
+      ctx.emit('result', `已读取 ${cookies.length} 个 Cookie`)
+    } else if (op === 'get') {
+      const cookie = await cookieGet(name, url || undefined)
+      ctx.variables[variable] = cookie ? cookie.value : ''
+      ctx.emit('result', cookie ? `已读取 ${name}` : `未找到 ${name}`)
+    } else if (op === 'set') {
+      if (!url) {
+        ctx.emit('error', 'cookie: 写入需要 URL')
+        return null
+      }
+      const expiry = Number(data['expirationDate'] ?? 0)
+      await cookieSet(name, value, url, expiry > 0 ? { expirationDate: expiry } : {})
+      ctx.emit('result', `已写入 ${name}`)
+    } else if (op === 'remove') {
+      if (!url) {
+        ctx.emit('error', 'cookie: 删除需要 URL')
+        return null
+      }
+      await cookieRemove(name, url)
+      ctx.emit('result', `已删除 ${name}`)
+    } else {
+      ctx.emit('error', `cookie: 不支持的操作 ${op}`)
+    }
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const clipboardBlock: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const op = String(data['op'] ?? 'get')
+  try {
+    if (op === 'get') {
+      const text = await clipboardGet()
+      ctx.variables[String(data['variableName'] ?? 'lastClipboard')] = text
+      ctx.emit('result', text.slice(0, 80))
+    } else {
+      const text = interpolate(String(data['text'] ?? ''), ctx.variables, ctx.refData)
+      await clipboardInsert(text)
+      ctx.emit('result', '已写入剪贴板')
+    }
+  } catch (error) {
+    ctx.emit('error', `剪贴板 ${op}: ${message(error)}`)
+  }
+  return null
+}
+
+const elementExistsExec: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const count = await elementExists(sel(data), ctx.signal)
+  const exists = count > 0
+  ctx.emit('result', exists ? `元素存在 (${count})` : '元素不存在')
+  return exists
+    ? (ctx.outputs?.['exists'] ?? ctx.defaultNext ?? null)
+    : (ctx.outputs?.['notExists'] ?? ctx.defaultNext ?? null)
+}
+
+const linkBlock: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const selector = sel(data)
+  const newTab = (data['newTab'] as boolean | undefined) ?? true
+  try {
+    const result = await execOnActiveTab(
+      { action: 'click_link', target: cssTarget(selector) },
+      ctx.signal,
+    )
+    const info = result.data as { href?: string; target?: string } | undefined
+    const href = info?.href ?? result.note ?? ''
+    if (newTab && info?.target === '_self') {
+      if (href) await driverNewTab(href)
+      ctx.emit('result', `已在新标签页打开 ${href}`)
+    } else {
+      await execOnActiveTab({ action: 'click', target: cssTarget(selector) }, ctx.signal)
+      ctx.emit('result', '已点击链接')
+    }
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const attributeValueExec: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const op = String(data['op'] ?? 'get')
+  const attribute = String(data['attribute'] ?? '')
+  const variable = String(data['variableName'] ?? 'lastAttribute')
+  const opData: Op = {
+    action: op === 'set' ? 'set_attribute' : 'get_attribute',
+    target: cssTarget(sel(data)),
+    attribute,
+  }
+  if (op === 'set') opData.value = interpolate(String(data['value'] ?? ''), ctx.variables, ctx.refData)
+  try {
+    const result = await execOnActiveTab(opData, ctx.signal)
+    if (op === 'get') {
+      ctx.variables[variable] = result.data ?? result.note ?? ''
+      ctx.emit('result', String(result.data ?? result.note ?? ''))
+    } else {
+      ctx.emit('result', `已设置属性 ${attribute}`)
+    }
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const goBackExec: BlockExecutor = async (_data, ctx) => {
+  assertActive(ctx)
+  try {
+    await goBack()
+    ctx.emit('result', '已后退')
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const forwardPage: BlockExecutor = async (_data, ctx) => {
+  assertActive(ctx)
+  try {
+    await goForward()
+    ctx.emit('result', '已前进')
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const tabUrlExec: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const variable = String(data['variableName'] ?? 'lastTabUrl')
+  try {
+    const current = data['scope'] === 'all'
+      ? await listAllTabUrls()
+      : await getActiveTabInfo()
+    ctx.variables[variable] = current
+    ctx.emit('result', Array.isArray(current) ? `共 ${current.length} 个标签页` : current.url)
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const activeTabExec: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const variable = String(data['variableName'] ?? 'lastActiveTab')
+  try {
+    const info = await getActiveTabInfo()
+    ctx.variables[variable] = info
+    ctx.emit('result', `${info.title} · ${info.url}`)
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const newWindowExec: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const url = data['url'] ? interpolate(String(data['url']), ctx.variables, ctx.refData) : undefined
+  try {
+    await driverNewWindow(url)
+    ctx.emit('result', '已打开新窗口')
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const createElementExec: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const html = interpolate(String(data['html'] ?? ''), ctx.variables, ctx.refData)
+  return runRaw({ action: 'create_element', value: html }, ctx)
+}
+
+const uploadFileExec: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const selector = sel(data)
+  const dataUrl = interpolate(String(data['fileData'] ?? ''), ctx.variables, ctx.refData)
+  try {
+    // Conversion of arbitrary local files into an in-page File is not available
+    // to MV3 extensions. We accept a data-url and hand it to the input; a
+    // re-run against a blob/data URL produces a usable File for many pipelines.
+    const opData: Op = { action: 'fill', target: cssTarget(selector), value: dataUrl }
+    await execOnActiveTab(opData, ctx.signal)
+    ctx.emit('result', '已设置文件输入')
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const handleDialogExec: BlockExecutor = async (_data, ctx) => {
+  assertActive(ctx)
+  return runRaw({ action: 'handle_dialog' }, ctx)
+}
+
+// --- Phase 3: data / variable operations ------------------------------------
+
+const increaseVariable: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const name = String(data['variableName'] ?? '')
+  const step = Number(interpolate(String(data['value'] ?? '1'), ctx.variables, ctx.refData))
+  const current = Number(ctx.variables[name] ?? data['incType'] === 'multiply' ? 1 : 0)
+  const next = data['incType'] === 'multiply' ? current * step : current + step
+  ctx.variables[name] = Number.isNaN(next) ? 0 : next
+  ctx.emit('result', `${name} = ${next}`)
+  return null
+}
+
+const sliceVariable: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const name = String(data['variableName'] ?? '')
+  const start = Number(data['start'] ?? 0)
+  const end = data['end'] === '' || data['end'] === undefined ? undefined : Number(data['end'])
+  const value = ctx.variables[name]
+  let sliced: unknown
+  if (typeof value === 'string') sliced = value.slice(start, end)
+  else if (Array.isArray(value)) sliced = value.slice(start, end)
+  else sliced = value
+  ctx.variables[String(data['output'] ?? name)] = sliced
+  ctx.emit('result', String(sliced ?? ''))
+  return null
+}
+
+const regexVariable: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const name = String(data['variableName'] ?? '')
+  const pattern = String(data['pattern'] ?? '')
+  const flags = String(data['flags'] ?? 'g')
+  const replace = interpolate(String(data['replace'] ?? ''), ctx.variables, ctx.refData)
+  const value = String(ctx.variables[name] ?? '')
+  try {
+    const regex = new RegExp(pattern, flags)
+    let result: string
+    if (data['operation'] === 'replace') result = value.replace(regex, replace)
+    else {
+      const flagsNoG = flags.replace('g', '')
+      const matches = value.match(new RegExp(pattern, flagsNoG)) ?? []
+      const all = flags.indexOf('g') !== -1 ? matches : [matches[0]].filter(Boolean)
+      result = JSON.stringify(all.map((m) => String(m)))
+    }
+    ctx.variables[String(data['output'] ?? name)] = result
+    ctx.emit('result', result.slice(0, 80))
+  } catch (error) {
+    ctx.emit('error', `regex: ${message(error)}`)
+  }
+  return null
+}
+
+/** Shared dataTable getter with a default empty array. */
+function tableOf(ctx: WorkflowExecCtx): unknown[] {
+  return Array.isArray(ctx.variables['dataTable']) ? (ctx.variables['dataTable'] as unknown[]) : []
+}
+
+const deleteDataExec: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const target = tableOf(ctx)
+  const key = Number(data['key'] ?? -1)
+  const all = data['clearAll'] === true
+  if (all) ctx.variables['dataTable'] = []
+  else if (key >= 0 && key < target.length) target.splice(key, 1)
+  ctx.emit('result', all ? '已清空数据表' : `已删除第 ${key} 行`)
+  return null
+}
+
+const sortDataExec: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const target = (ctx.variables['dataTable'] as Record<string, unknown>[]) ?? []
+  const field = String(data['field'] ?? '')
+  const direction = String(data['direction'] ?? 'asc') === 'desc' ? -1 : 1
+  const sorted = [...target].filter((row) => row && typeof row === 'object')
+  sorted.sort((a, b) => {
+    const va = field ? a[field] : a['value']
+    const vb = field ? b[field] : b['value']
+    if (typeof va === 'number' && typeof vb === 'number') return (va - vb) * direction
+    return String(va ?? '').localeCompare(String(vb ?? '')) * direction
+  })
+  ctx.variables['dataTable'] = sorted
+  ctx.emit('result', `已按 ${field || '值'} 排序`)
+  return null
+}
+
+const dataMapping: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const rows = tableOf(ctx).filter((row): row is Record<string, unknown> => !!row && typeof row === 'object')
+  const expression = String(data['mapping'] ?? 'item')
+  let mapped: unknown
+  try {
+    const fn = new Function('item', 'index', 'vars', `return (${expression})`)
+    mapped = rows.map((item, index) => fn(item, index, ctx.variables))
+  } catch (error) {
+    ctx.emit('error', `data-mapping: ${message(error)}`)
+    return null
+  }
+  ctx.variables[String(data['output'] ?? 'mappedData')] = mapped
+  ctx.variables['lastMappedData'] = mapped
+  ctx.emit('result', `已映射 ${rows.length} 行`)
+  return null
+}
+
+const logData: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const text = interpolate(String(data['text'] ?? ''), ctx.variables, ctx.refData)
+  ctx.emit('info', text)
+  return null
+}
+
+const workflowState: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const op = String(data['op'] ?? 'get')
+  const variable = String(data['variableName'] ?? 'state')
+  if (op === 'set') {
+    const value = interpolate(String(data['value'] ?? ''), ctx.variables, ctx.refData)
+    ctx.variables[variable] = value
+    ctx.emit('result', `已设置状态 ${variable}`)
+  } else {
+    const value = ctx.variables[variable]
+    ctx.variables['lastState'] = value
+    ctx.emit('result', String(value ?? ''))
+  }
+  return null
+}
+
+// --- Phase 5: integration / service blocks ----------------------------------
+
+const parameterPrompt: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const prompt = interpolate(String(data['prompt'] ?? '请输入值'), ctx.variables, ctx.refData)
+  const fallback = interpolate(String(data['defaultValue'] ?? ''), ctx.variables, ctx.refData)
+  // Engine is autonomous; surface the prompt and fall back to the default or
+  // an existing variable of the same name so workflows that pre-seed input work.
+  const variable = String(data['variableName'] ?? 'userInput')
+  if (ctx.variables[variable] === undefined && fallback !== '') ctx.variables[variable] = fallback
+  ctx.emit('info', `需要输入：${prompt}`)
+  ctx.emit('result', String(ctx.variables[variable] ?? ''))
+  return null
+}
+
+const switchToExec: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  // The driver already searches all frames; record the iframe target as context.
+  const frame = String(data['frameSelector'] ?? '')
+  ctx.emit('info', frame ? `已定位 iframe ${frame}` : '已定位到顶层页面')
+  return null
+}
+
+const triggerEventExec: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const event = String(data['event'] ?? '')
+  const detail = interpolate(String(data['detail'] ?? 'null'), ctx.variables, ctx.refData)
+  return runRaw({ action: 'trigger_event', target: cssTarget(sel(data)), attribute: event, value: detail }, ctx)
+}
+
+const browserEvent: BlockExecutor = async (_data, ctx) => {
+  assertActive(ctx)
+  ctx.emit('info', 'browser-event: 页面事件监听需常驻 content script，当前为占位实现')
+  return null
+}
+
+const handleDownload: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const filename = String(data['filename'] ?? '')
+  const variable = String(data['variableName'] ?? 'lastDownload')
+  try {
+    const items = await chrome.downloads.search({})
+    const match = filename
+      ? items.find((item) => item.filename.includes(filename))
+      : items[0]
+    ctx.variables[variable] = match ? { id: match.id, filename: match.filename, url: match.url } : null
+    ctx.emit('result', match ? `最近下载: ${match.filename}` : '未找到匹配下载')
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const saveAssetsExec: BlockExecutor = async (_data, ctx) => {
+  assertActive(ctx)
+  ctx.emit('info', 'save-assets: 资源保存需工作区目标，当前为占位实现')
+  return null
+}
+
+const proxyExec: BlockExecutor = async (_data, ctx) => {
+  assertActive(ctx)
+  ctx.emit('info', 'proxy: 代理配置需浏览器级设置，当前为占位实现')
+  return null
+}
+
+const googleSheets: BlockExecutor = async (_data, ctx) => {
+  assertActive(ctx)
+  ctx.emit('error', 'google-sheets: 需要 OAuth 凭据，尚未配置')
+  return null
+}
+
+const googleDrive: BlockExecutor = async (_data, ctx) => {
+  assertActive(ctx)
+  ctx.emit('error', 'google-drive: 需要 OAuth 凭据，尚未配置')
+  return null
+}
+
+const waitConnections: BlockExecutor = async (_data, ctx) => {
+  assertActive(ctx)
+  ctx.emit('info', 'wait-connections: 等待网络连接，当前为占位实现')
+  return null
+}
+
+const note: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const text = String(data['text'] ?? '')
+  if (text) ctx.emit('info', text)
+  return null
+}
+
+const blocksGroup: BlockExecutor = async (_data) => {
+  // A group is a structural container — its body routes via its outgoing edge.
+  return null
+}
+
+// --- Phase 1: form reading / radio ------------------------------------------
+
+const getForm: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const variable = String(data['variableName'] ?? 'lastForm')
+  const selector = data['cssSelector'] ? (data['cssSelector'] as string) : undefined
+  try {
+    const op: Op = { action: 'read_form' }
+    if (selector) op.value = selector
+    const result = await execOnActiveTab(op, ctx.signal)
+    ctx.variables[variable] = result.data ?? {}
+    ctx.emit('result', JSON.stringify(result.data ?? {}).slice(0, 80))
+  } catch (error) {
+    ctx.emit('error', message(error))
+  }
+  return null
+}
+
+const selectRadio: BlockExecutor = async (data, ctx) => {
+  assertActive(ctx)
+  const checked = data['value'] !== '' && data['value'] !== false
+  return runRaw({ action: 'set_checkbox', target: cssTarget(sel(data)), value: checked }, ctx)
+}
+
+// --- Placeholders for engine-handled blocks ----------------------------------
+
+/** Emit an "info" notice and let the engine continue. */
+function placeholder(blockId: string): BlockExecutor {
+  return (_data, ctx) => {
+    ctx.emit('info', '尚未实现: ' + blockId)
+    return Promise.resolve(null)
+  }
+}
+
+/**
+ * Block-executor registry, keyed by block id (the same ids defined in
+ * `lib/workflow/registry.ts`). The engine resolves the block id from
+ * `WorkflowNode.data.blockId` (falling back to the legacy `label` field) and
+ * dispatches through this map, then passes the node's `data.values` bag as
+ * the executor's `data` argument.
+ */
+export const EXECUTORS: Record<string, BlockExecutor> = {
+  // browser
+  'click': click,
+  'fill': fill,
+  'select-option': selectOption,
+  'scroll': scroll,
+  'press-key': pressKey,
+  'wait-for': waitFor,
+  'take-screenshot': takeScreenshot,
+  'get-text': getText,
+  'hover': hover,
+  'set-checkbox': setCheckbox,
+  'get-form': getForm,
+  'set-radio': selectRadio,
+  // navigation
+  'open-url': openUrl,
+  'new-tab': newTabExec,
+  'switch-tab': switchTabExec,
+  'close-tab': closeTabExec,
+  'reload-tab': reloadTabExec,
+  // data
+  'set-variable': setVariable,
+  'get-variable': getVariable,
+  'insert-data': insertData,
+  'export-data': exportData,
+  'increase-variable': increaseVariable,
+  'slice-variable': sliceVariable,
+  'regex-variable': regexVariable,
+  'delete-data': deleteDataExec,
+  'sort-data': sortDataExec,
+  'data-mapping': dataMapping,
+  'log-data': logData,
+  'workflow-state': workflowState,
+  // control-flow
+  'condition': condition,
+  'loop-data': placeholder('loop-data'),
+  'repeat-task': placeholder('repeat-task'),
+  'while-loop': placeholder('while-loop'),
+  'loop-elements': placeholder('loop-elements'),
+  'delay': delay,
+  'breakpoint': breakpoint,
+  // browser actions (phase 2)
+  'cookie': cookieBlock,
+  'clipboard': clipboardBlock,
+  'element-exists': elementExistsExec,
+  'link': linkBlock,
+  'attribute-value': attributeValueExec,
+  'go-back': goBackExec,
+  'forward-page': forwardPage,
+  'tab-url': tabUrlExec,
+  'active-tab': activeTabExec,
+  'new-window': newWindowExec,
+  'create-element': createElementExec,
+  'upload-file': uploadFileExec,
+  'handle-dialog': handleDialogExec,
+  // integration
+  'webhook': webhook,
+  'notification': notification,
+  'javascript-code': javascriptCode,
+  'ai-prompt': aiPrompt,
+  'execute-workflow': placeholder('execute-workflow'),
+  'parameter-prompt': parameterPrompt,
+  'switch-to': switchToExec,
+  'trigger-event': triggerEventExec,
+  'browser-event': browserEvent,
+  'handle-download': handleDownload,
+  'save-assets': saveAssetsExec,
+  'proxy': proxyExec,
+  'google-sheets': googleSheets,
+  'google-drive': googleDrive,
+  'wait-connections': waitConnections,
+  'note': note,
+  'blocks-group': blocksGroup,
+  // trigger
+  'visit-web': noop,
+  'schedule': noop,
+  'manual': noop,
+  'context-menu': noop,
+  'on-startup': noop,
+  'keyboard-shortcut': noop,
+  'date': noop,
+  'specific-day': noop,
+  'element-change': noop,
+}

--- a/src/background/workflow-engine/run-workflow.ts
+++ b/src/background/workflow-engine/run-workflow.ts
@@ -1,0 +1,84 @@
+/**
+ * Integration layer that wires the pure engine to a tracked "running task".
+ *
+ * Starts a `running-tasks` entry so the run appears on the board, streams every
+ * engine step into its progress log, and finishes it with the settling outcome.
+ * This is the entry point callers (chat, scheduler, Feishu bot, manual run)
+ * use to actually execute a workflow.
+ *
+ * @module background/workflow-engine/run-workflow
+ */
+
+import type { Workflow } from '../../lib/workflow/types'
+import { addStep, finishRun, startRun, type RunSource } from '../running-tasks'
+import { countElements } from '../driver'
+import { runWorkflow } from './engine'
+
+export interface ExecuteWorkflowOptions {
+  source: RunSource
+  taskId?: string
+  feishuChatId?: string
+  variables?: Record<string, unknown>
+  /** Optional caller-side sink for each engine step, fired alongside the run log. */
+  onStep?: (kind: string, nodeId: string, text: string) => void
+}
+
+export interface ExecuteWorkflowResult {
+  runId: string
+  outcome: 'ok' | 'cancelled' | 'failed'
+  summary?: string
+  error?: string
+}
+
+/**
+ * Run `workflow` as a tracked task, mapping engine steps onto the run's log.
+ * A thrown engine error (e.g. a cancellation escaping the engine) is treated as
+ * a `'cancelled'` abort so the board never shows a crashed run as `'ok'`.
+ */
+export async function executeWorkflow(
+  workflow: Workflow,
+  opts: ExecuteWorkflowOptions,
+): Promise<ExecuteWorkflowResult> {
+  const run = startRun({
+    label: workflow.name,
+    source: opts.source,
+    taskId: opts.taskId,
+    feishuChatId: opts.feishuChatId,
+  })
+  const runId = run.runId
+
+  try {
+    const result = await runWorkflow(workflow, {
+      variables: opts.variables,
+      signal: run.controller.signal,
+      loopElementCounter: (selector, signal) => countElements(selector, signal),
+      onStep: (kind, nodeId, text) => {
+        // status / result / error / info become progress lines verbatim.
+        addStep(runId, kind, text)
+        // Plus a "tool" marker so logs show which block is on stage.
+        addStep(runId, 'tool', '→ ' + nodeId)
+        // Surface to the caller (e.g. Feishu streaming) alongside the run log.
+        opts.onStep?.(kind, nodeId, text)
+      },
+    })
+    const outcome: ExecuteWorkflowResult['outcome'] = run.controller.signal.aborted
+      ? 'cancelled'
+      : result.outcome
+    const summary = result.summary
+    // For a failed run, prefer the dedicated error field; fall back to summary
+    // so legacy failures still show something in the history error block.
+    const error = outcome === 'failed' ? (result.error ?? summary) : undefined
+    finishRun(runId, { outcome, summary, error })
+    return { runId, outcome, summary, error }
+  } catch (e) {
+    // A cancellation or engine error that leaked out of runWorkflow.
+    const aborted = run.controller.signal.aborted || (e instanceof DOMException && e.name === 'AbortError')
+    if (aborted) {
+      finishRun(runId, { outcome: 'cancelled' })
+      return { runId, outcome: 'cancelled' }
+    }
+    const text = e instanceof Error ? e.message : String(e)
+    finishRun(runId, { outcome: 'failed', summary: text.split('\n')[0], error: text })
+    return { runId, outcome: 'failed', summary: text.split('\n')[0], error: text }
+  }
+}

--- a/src/inpage/kernel.ts
+++ b/src/inpage/kernel.ts
@@ -663,6 +663,47 @@ export function runOp(op: Op): OpResult {
     }
   }
 
+  // --- Capture (full-page / element) -----------------------------------------
+
+  /**
+   * Renders a DOM node (the document or a matched element) to a PNG data URL by
+   * serializing it into an `<svg><foreignObject>`, drawing that into a canvas,
+   * and reading `toDataURL`. Returns `null` when the target is missing or the
+   * canvas is tainted (e.g. cross-origin images without CORS).
+   */
+  async function captureNode(selector: string): Promise<OpResult> {
+    const host = selector
+      ? (document.querySelector(selector) as HTMLElement | null)
+      : document.documentElement
+    if (!host) {
+      return { ...base(), ok: false, found: false, error: `capture: 未找到元素 "${selector}"` }
+    }
+    try {
+      const width = host.scrollWidth || host.offsetWidth || 1280
+      const height = host.scrollHeight || host.offsetHeight || 800
+      const markup = new XMLSerializer().serializeToString(host)
+      const data = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(markup)
+      const image = new Image()
+      const decoded = await new Promise<HTMLImageElement>((resolve, reject) => {
+        image.onload = (): void => resolve(image)
+        image.onerror = (): void => reject(new Error('capture: SVG 加载失败'))
+        image.src = data
+      })
+      const canvas = document.createElement('canvas')
+      canvas.width = width
+      canvas.height = height
+      const context = canvas.getContext('2d')
+      if (!context) throw new Error('capture: 无法创建画布')
+      context.fillStyle = '#ffffff'
+      context.fillRect(0, 0, width, height)
+      context.drawImage(decoded, 0, 0, width, height)
+      return { ...base(), ok: true, found: true, note: 'captured', data: canvas.toDataURL('image/png') }
+    } catch (error) {
+      const text = error instanceof Error ? error.message : String(error)
+      return { ...base(), ok: false, found: true, error: `capture: ${text}` }
+    }
+  }
+
   // --- Dispatch --------------------------------------------------------------
 
   try {
@@ -671,13 +712,20 @@ export function runOp(op: Op): OpResult {
       return { ...base(), ok: true, found: true, page }
     }
 
+    if (op.action === 'capture') {
+      // Returns a Promise; chrome.scripting.executeScript awaits it. The driver
+      // reads `injection.result` after resolution, which is an OpResult.
+      return captureNode(op.value ? String(op.value) : '') as unknown as OpResult
+    }
+
     if (op.action === 'scroll' && !op.target) {
       const spec = op.scroll ?? { mode: 'by' as const, y: 600 }
+      const behavior: ScrollBehavior = spec.mode === 'incremental' || 'smooth' in spec && spec.smooth ? 'smooth' : 'auto'
       try {
-        if (spec.mode === 'top') window.scrollTo({ top: 0, left: 0 })
+        if (spec.mode === 'top') window.scrollTo({ top: 0, left: 0, behavior })
         else if (spec.mode === 'bottom')
-          window.scrollTo({ top: document.documentElement.scrollHeight ?? 0, left: 0 })
-        else if (spec.mode === 'by') window.scrollBy({ top: spec.y ?? 0, left: spec.x ?? 0 })
+          window.scrollTo({ top: document.documentElement.scrollHeight ?? 0, left: 0, behavior })
+        else window.scrollBy({ top: 'y' in spec ? (spec.y ?? 0) : 0, left: 'x' in spec ? (spec.x ?? 0) : 0, behavior })
       } catch {
         /* no scrolling */
       }
@@ -692,6 +740,75 @@ export function runOp(op: Op): OpResult {
       active.dispatchEvent(new KeyboardEvent('keydown', init))
       active.dispatchEvent(new KeyboardEvent('keyup', init))
       return { ...base(), ok: true, found: true, note: `pressed ${key}` }
+    }
+
+    if (op.action === 'element_exists' || op.action === 'count_elements') {
+      const selector = String(op.value ?? '')
+      const matches = safeQuery(selector)
+      const count = matches.length
+      if (op.action === 'count_elements')
+        return { ...base(), ok: true, found: true, note: `count=${count}`, data: count }
+      return {
+        ...base(),
+        ok: true,
+        found: count > 0,
+        note: count > 0 ? `存在 ${count} 个匹配元素` : '未找到匹配元素',
+        data: count,
+      }
+    }
+
+    if (op.action === 'read_form') {
+      const results: Record<string, unknown> = {}
+      const selector = op.value ? String(op.value) : 'input, select, textarea'
+      const controls = safeQuery(selector)
+      for (let i = 0; i < controls.length; i += 1) {
+        const control = controls[i] as HTMLInputElement | HTMLTextAreaElement
+        const name = control.getAttribute('name') || control.id || `field${i}`
+        if (name in results) continue
+        if (control instanceof HTMLTextAreaElement) {
+          results[name] = control.value
+        } else if (control instanceof HTMLSelectElement) {
+          results[name] = control.multiple
+            ? Array.from(control.selectedOptions).map((o) => o.value)
+            : control.value
+        } else {
+          const type = (control.type || 'text').toLowerCase()
+          if (type === 'checkbox') results[name] = control.checked
+          else if (type === 'radio') {
+            if (control.checked) results[name] = control.value
+          } else results[name] = control.value
+        }
+      }
+      return { ...base(), ok: true, found: true, note: '已读取表单', data: results }
+    }
+
+    if (op.action === 'create_element') {
+      const html = String(op.value ?? '')
+      const wrapper = document.createElement('div')
+      wrapper.innerHTML = html
+      const inserted = Array.prototype.slice.call(wrapper.children) as Element[]
+      for (const child of inserted) document.body.appendChild(child)
+      return { ...base(), ok: true, found: true, note: `created ${inserted.length} element(s)` }
+    }
+
+    if (op.action === 'handle_dialog') {
+      try {
+        // Auto-accept confirm() and suppress beforeunload prompts so a workflow
+        // that navigates or triggers dialogs keeps moving. Goes through
+        // descriptors so pages that froze these globals can still be coerced.
+        const set = (target: unknown, key: string, value: unknown): void => {
+          try {
+            Object.defineProperty(target, key, { value, configurable: true, writable: true })
+          } catch {
+            ;(target as Record<string, unknown>)[key] = value
+          }
+        }
+        set(window, 'onbeforeunload', null)
+        set(window, 'confirm', () => true)
+      } catch {
+        /* handlers may be non-configurable on some pages */
+      }
+      return { ...base(), ok: true, found: true, note: '对话框处理已启用' }
     }
 
     if (!op.target) return fail(`${op.action} needs a target element.`, false)
@@ -724,12 +841,17 @@ export function runOp(op: Op): OpResult {
 
     if (op.action === 'scroll') {
       const spec = op.scroll ?? { mode: 'into_view' as const }
+      const behavior: ScrollBehavior = spec.mode === 'into_view' ? 'auto' : spec.mode === 'incremental' || 'smooth' in spec && spec.smooth ? 'smooth' : 'auto'
       try {
         if (spec.mode === 'into_view') scrollIntoView(element)
-        else if (spec.mode === 'by')
-          element.scrollBy?.({ top: spec.y ?? 0, left: spec.x ?? 0 })
-        else if (spec.mode === 'top') element.scrollTo?.({ top: 0 })
-        else element.scrollTo?.({ top: element.scrollHeight })
+        else if (spec.mode === 'by' || spec.mode === 'incremental') {
+          ;(element as HTMLElement).scrollBy?.({
+            top: 'y' in spec ? (spec.y ?? 0) : 0,
+            left: 'x' in spec ? (spec.x ?? 0) : 0,
+            behavior,
+          })
+        } else if (spec.mode === 'top') (element as HTMLElement).scrollTo?.({ top: 0, behavior })
+        else (element as HTMLElement).scrollTo?.({ top: element.scrollHeight, behavior })
       } catch {
         /* no scrolling */
       }
@@ -850,6 +972,54 @@ export function runOp(op: Op): OpResult {
         found: true,
         ...(ok ? {} : { error: 'The control did not change state.' }),
       })
+    }
+
+    if (op.action === 'get_attribute') {
+      const attribute = String(op.attribute ?? '')
+      if (!attribute) return withMeta(fail('get_attribute needs an attribute name.'))
+      const value = element.getAttribute(attribute) ?? ''
+      return withMeta({ ...base(), ok: true, found: true, note: value, data: value })
+    }
+
+    if (op.action === 'set_attribute') {
+      const attribute = String(op.attribute ?? '')
+      if (!attribute) return withMeta(fail('set_attribute needs an attribute name.'))
+      const value = String(op.value ?? '')
+      if (value === '') element.removeAttribute(attribute)
+      else element.setAttribute(attribute, value)
+      return withMeta({ ...base(), ok: true, found: true, note: `set ${attribute}` })
+    }
+
+    if (op.action === 'click_link') {
+      const href = (element as HTMLAnchorElement).href
+      const tag = element.tagName.toLowerCase()
+      if (tag !== 'a' || !href) return withMeta(fail(`${describeElement(element)} is not a clickable link.`))
+      const target = (element as HTMLAnchorElement).target
+      return withMeta({
+        ...base(),
+        ok: true,
+        found: true,
+        mayNavigate: true,
+        note: href,
+        data: { href, target: target ?? '_self' },
+      })
+    }
+
+    if (op.action === 'trigger_event') {
+      const eventName = String(op.attribute ?? '')
+      if (!eventName) return withMeta(fail('trigger_event needs an event name.'))
+      let detail: unknown
+      try {
+        detail = JSON.parse(String(op.value ?? 'null'))
+      } catch {
+        detail = String(op.value ?? '')
+      }
+      const useBubbles = () => {
+        const maybe = eventName.toLowerCase()
+        return maybe.indexOf('mouse') === -1 && maybe.indexOf('click') === -1
+      }
+      element.dispatchEvent(new CustomEvent(eventName, { bubbles: useBubbles(), detail }))
+      return withMeta({ ...base(), ok: true, found: true, note: `dispatched ${eventName}` })
     }
 
     if (op.action === 'press_key') {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -47,8 +47,34 @@ export interface Messages {
   tabChat: string
   tabSkills: string
   tabTasks: string
+  tabWorkflows: string
   tabData: string
   tabSettings: string
+  tabHistory: string
+  tabMore: string
+
+  // History tab
+  histConversations: string
+  histTasks: string
+  histWorkflows: string
+  histOperations: string
+  histEmpty: string
+  histBatchDelete: string
+  histDeleteSelected: string
+  histSelectAll: string
+  histDeleteConfirm: (params: { count: number }) => string
+  histWorkflowRuns: string
+  histTaskRuns: string
+  histDetailTitle: string
+  histEmptyRuns: string
+  histOutcomeOk: string
+  histOutcomeFailed: string
+  histOutcomeCancelled: string
+  histOutcomeSkipped: string
+  /** Read-only JSON block label for a history entry's arguments. */
+  histArgs: string
+  /** Shown when a run has no recorded steps and is expanded. */
+  histNoSteps: string
 
   // Tasks
   tasksTitle: string
@@ -126,6 +152,27 @@ export interface Messages {
   tasksFeishuBotWarn: string
   taskTemplateGithubName: string
 
+  // Workflows
+  workflowsEmpty: string
+  workflowsNew: string
+  workflowsRunNow: string
+  workflowsEdit: string
+  workflowsDeleteConfirm: string
+  workflowsTriggerManual: string
+  workflowsTriggerScheduled: string
+  workflowsTriggerContextMenu: string
+  workflowsTriggerVisitWeb: string
+  workflowsTriggerGithub: string
+  workflowsTriggerFeishu: string
+  workflowsTriggerNone: string
+  workflowsLastRun: string
+  workflowsRunHistory: string
+  workflowsRunStatusNever: string
+  workflowsExport: string
+  workflowsImport: string
+  workflowsImportInvalid: string
+  workflowsImported: (params: { count: number }) => string
+
   // Common
   save: string
   cancel: string
@@ -163,6 +210,11 @@ export interface Messages {
   chatPlaceholderWithSkills: string
   /** Shown in the slash menu when no skill matches what was typed. */
   chatSlashNoMatch: string
+  /** Ask whether to persist this session's operations as a reusable workflow. */
+  chatSaveWorkflowPrompt: (params: { steps: number }) => string
+  chatSaveWorkflowSave: string
+  chatSaveWorkflowSkip: string
+  chatSaveWorkflowSaved: (params: { name: string }) => string
 
   // Agent mode
   modeLabel: string
@@ -371,6 +423,9 @@ export interface Messages {
   dataHistoryIntro: string
   dataHistoryEmpty: string
   dataClearHistory: string
+  dataHistoryToWorkflow: string
+  dataHistoryToWorkflowDone: string
+  dataHistoryToWorkflowEmpty: string
   dataHistoryWhen: string
   dataConversation: string
   dataDeclined: string
@@ -406,8 +461,33 @@ const en: Messages = {
   tabChat: 'Chat',
   tabSkills: 'Skills',
   tabTasks: 'Tasks',
+  tabWorkflows: 'Workflows',
   tabData: 'Data',
   tabSettings: 'Settings',
+  tabHistory: 'History',
+  tabMore: 'More',
+
+  // History tab
+  histConversations: 'Conversations',
+  histTasks: 'Task runs',
+  histWorkflows: 'Workflows',
+  histOperations: 'Operations',
+  histEmpty: 'No records yet.',
+  histBatchDelete: 'Delete selected',
+  histDeleteSelected: 'Delete selected',
+  histSelectAll: 'Select all',
+  histDeleteConfirm: ({ count }) =>
+    `Delete ${count} selected record${count > 1 ? 's' : ''}? This cannot be undone.`,
+  histWorkflowRuns: 'Workflow runs',
+  histTaskRuns: 'Task runs',
+  histDetailTitle: 'Steps',
+  histEmptyRuns: 'No runs yet.',
+  histOutcomeOk: 'ok',
+  histOutcomeFailed: 'failed',
+  histOutcomeCancelled: 'cancelled',
+  histOutcomeSkipped: 'skipped',
+  histArgs: 'Arguments',
+  histNoSteps: 'No recorded steps.',
 
   tasksTitle: 'Run tasks',
   tasksSubtitle:
@@ -488,6 +568,26 @@ const en: Messages = {
     'While the browser is fully idle or the machine is asleep, the extension cannot be reached; it reconnects within about a minute of waking. For truly always-on remote control, add a small relay server.',
   taskTemplateGithubName: 'PRs to review',
 
+  workflowsEmpty: 'No workflows yet. Create one to start automating.',
+  workflowsNew: 'New',
+  workflowsRunNow: 'Run',
+  workflowsEdit: 'Edit',
+  workflowsDeleteConfirm: 'Delete this workflow?',
+  workflowsTriggerManual: 'Manual',
+  workflowsTriggerScheduled: 'Scheduled',
+  workflowsTriggerContextMenu: 'Context menu',
+  workflowsTriggerVisitWeb: 'Visit web',
+  workflowsTriggerGithub: 'GitHub',
+  workflowsTriggerFeishu: 'Feishu',
+  workflowsTriggerNone: 'No trigger',
+  workflowsLastRun: 'Last run',
+  workflowsRunHistory: 'Run history',
+  workflowsRunStatusNever: 'Never',
+  workflowsExport: 'Export',
+  workflowsImport: 'Import',
+  workflowsImportInvalid: 'Invalid workflow file(s): at least one export could not be read.',
+  workflowsImported: ({ count }) => `Imported ${count} workflow(s).`,
+
   save: 'Save',
   cancel: 'Cancel',
   edit: 'Edit',
@@ -522,6 +622,11 @@ const en: Messages = {
   chatPlaceholderWithSkills:
     'Message… (Enter to send, Shift+Enter for a new line, / for skills)',
   chatSlashNoMatch: 'No matching skill',
+  chatSaveWorkflowPrompt: ({ steps }) =>
+    `This session performed ${steps} step${steps > 1 ? 's' : ''} that can be reused. Save them as a workflow?`,
+  chatSaveWorkflowSave: 'Save as workflow',
+  chatSaveWorkflowSkip: 'Skip',
+  chatSaveWorkflowSaved: ({ name }) => `Saved workflow: ${name}`,
 
   modeLabel: 'Mode',
   modeChat: 'Chat',
@@ -748,6 +853,9 @@ const en: Messages = {
     'A log of every page action the agent performed, so you can review or delete what happened.',
   dataHistoryEmpty: 'No actions recorded yet.',
   dataClearHistory: 'Clear all',
+  dataHistoryToWorkflow: 'Save as workflow',
+  dataHistoryToWorkflowDone: 'Saved the action steps as a workflow.',
+  dataHistoryToWorkflowEmpty: 'No rebuildable workflow steps in this group.',
   dataHistoryWhen: 'When',
   dataConversation: 'Conversation',
   dataDeclined: 'declined',
@@ -782,8 +890,32 @@ const zhCN: Messages = {
   tabChat: '对话',
   tabSkills: '技能',
   tabTasks: '任务',
+  tabWorkflows: '工作流',
   tabData: '数据',
   tabSettings: '设置',
+  tabHistory: '历史',
+  tabMore: '更多',
+
+  // History tab
+  histConversations: '对话记录',
+  histTasks: '任务记录',
+  histWorkflows: '工作流记录',
+  histOperations: '操作记录',
+  histEmpty: '暂无记录',
+  histBatchDelete: '批量删除',
+  histDeleteSelected: '删除选中',
+  histSelectAll: '全选',
+  histDeleteConfirm: ({ count }) => `确认删除选中的 ${count} 条记录？此操作不可撤销。`,
+  histWorkflowRuns: '工作流运行历史',
+  histTaskRuns: '任务运行历史',
+  histDetailTitle: '执行步骤',
+  histEmptyRuns: '暂无运行记录',
+  histOutcomeOk: '成功',
+  histOutcomeFailed: '失败',
+  histOutcomeCancelled: '已取消',
+  histOutcomeSkipped: '已跳过',
+  histArgs: '参数',
+  histNoSteps: '暂无步骤记录',
 
   tasksTitle: '运行任务',
   tasksSubtitle:
@@ -864,6 +996,26 @@ const zhCN: Messages = {
     '浏览器完全空闲或电脑睡眠时扩展无法被触达，唤醒后约一分钟内会自动重连。若需要真正始终在线的远程控制，建议增加一个小型中继服务。',
   taskTemplateGithubName: '待我 review 的 PR',
 
+  workflowsEmpty: '还没有工作流，创建一个开始自动化。',
+  workflowsNew: '新建',
+  workflowsRunNow: '运行',
+  workflowsEdit: '编辑',
+  workflowsDeleteConfirm: '删除该工作流？',
+  workflowsTriggerManual: '手动',
+  workflowsTriggerScheduled: '定时',
+  workflowsTriggerContextMenu: '右键菜单',
+  workflowsTriggerVisitWeb: '访问网页',
+  workflowsTriggerGithub: 'GitHub',
+  workflowsTriggerFeishu: '飞书',
+  workflowsTriggerNone: '无触发器',
+  workflowsLastRun: '上次运行',
+  workflowsRunHistory: '运行历史',
+  workflowsRunStatusNever: '未运行',
+  workflowsExport: '导出',
+  workflowsImport: '导入',
+  workflowsImportInvalid: '无效的工作流文件：至少一个导出无法读取。',
+  workflowsImported: ({ count }) => `已导入 ${count} 个工作流。`,
+
   save: '保存',
   cancel: '取消',
   edit: '编辑',
@@ -894,6 +1046,11 @@ const zhCN: Messages = {
   chatSkillGoSelection: ({ name }) => `请用"${name}"技能处理我在页面上选中的内容。`,
   chatPlaceholderWithSkills: '输入消息…（Enter 发送，Shift+Enter 换行，/ 选择技能）',
   chatSlashNoMatch: '没有匹配的技能',
+  chatSaveWorkflowPrompt: ({ steps }) =>
+    `本次会话共执行了 ${steps} 步可复用操作，是否保存为工作流？`,
+  chatSaveWorkflowSave: '保存为工作流',
+  chatSaveWorkflowSkip: '跳过',
+  chatSaveWorkflowSaved: ({ name }) => `已保存工作流：${name}`,
 
   modeLabel: '模式',
   modeChat: '聊天',
@@ -1104,6 +1261,9 @@ const zhCN: Messages = {
   dataHistoryIntro: '助手在网页上执行过的每一步操作记录，可随时查看或删除。',
   dataHistoryEmpty: '暂无操作记录。',
   dataClearHistory: '全部清空',
+  dataHistoryToWorkflow: '保存为工作流',
+  dataHistoryToWorkflowDone: '已将操作步骤保存为工作流。',
+  dataHistoryToWorkflowEmpty: '该组中没有可重建为工作流的操作。',
   dataHistoryWhen: '时间',
   dataConversation: '会话',
   dataDeclined: '已拒绝',

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -26,6 +26,7 @@ import type {
   TaskRunLog,
 } from './scheduler-types'
 import type { RunOutcomeKind, RunSource, RunStep } from '../background/running-tasks'
+import type { Workflow } from './workflow/types'
 
 /** Aggregated token usage for one agent turn (summed across all tool rounds). */
 export interface TurnTokenUsage {
@@ -119,6 +120,14 @@ export type Command =
   | { type: 'feishu.save'; config: FeishuConfig }
   | { type: 'feishu.test' }
 
+  // --- Workflows ---
+  | { type: 'workflows.list' }
+  | { type: 'workflows.get'; id: string }
+  | { type: 'workflows.save'; workflow: Workflow }
+  | { type: 'workflows.delete'; id: string }
+  | { type: 'workflows.run'; id: string }
+  | { type: 'workflows.running' }
+
 /** Replies, discriminated by the command that produced them. */
 export type CommandResult =
   | { type: 'settings'; settings: Settings }
@@ -167,6 +176,14 @@ export type CommandResult =
   | { type: 'feishu.get'; config: FeishuConfig }
   | { type: 'feishu.save' }
   | { type: 'feishu.test'; ok: boolean; message?: string }
+
+  // --- Workflows ---
+  | { type: 'workflows.list'; workflows: Workflow[] }
+  | { type: 'workflows.get'; workflow?: Workflow }
+  | { type: 'workflows.save' }
+  | { type: 'workflows.delete' }
+  | { type: 'workflows.run'; outcome: { ok: boolean; skipped: boolean; summary: string; error?: string } }
+  | { type: 'workflows.running'; runs: RunningTaskView[]; finished: FinishedTaskView[] }
 
 /** Envelope so a failed command never looks like a successful one. */
 export type CommandResponse =

--- a/src/lib/ops.ts
+++ b/src/lib/ops.ts
@@ -45,13 +45,24 @@ export type ActionName =
   | 'scroll'
   | 'wait_for'
   | 'snapshot'
+  | 'element_exists'
+  | 'get_attribute'
+  | 'set_attribute'
+  | 'click_link'
+  | 'read_form'
+  | 'create_element'
+  | 'handle_dialog'
+  | 'count_elements'
+  | 'trigger_event'
+  | 'capture'
 
 /** What `scroll` should do. */
 export type ScrollSpec =
   | { mode: 'into_view' }
-  | { mode: 'by'; x?: number; y?: number }
-  | { mode: 'top' }
-  | { mode: 'bottom' }
+  | { mode: 'by'; x?: number; y?: number; smooth?: boolean }
+  | { mode: 'incremental'; x?: number; y?: number }
+  | { mode: 'top'; smooth?: boolean }
+  | { mode: 'bottom'; smooth?: boolean }
 
 /** One operation, handed across the structured-clone boundary. */
 export interface Op {
@@ -59,6 +70,8 @@ export interface Op {
   target?: Target
   /** Text to type, option to choose, or key to press. */
   value?: string | string[] | boolean
+  /** Attribute name for `get_attribute` / `set_attribute` / `trigger_event`. */
+  attribute?: string
   scroll?: ScrollSpec
   /** Whether to clear an input before typing (default true for `fill`). */
   clear?: boolean
@@ -132,4 +145,6 @@ export interface OpResult {
   page?: PageSnapshot
   mayNavigate?: boolean
   note?: string
+  /** Structured payload for data-producing ops (attribute, form, count). */
+  data?: unknown
 }

--- a/src/lib/scheduler-types.ts
+++ b/src/lib/scheduler-types.ts
@@ -31,6 +31,10 @@ export type TaskKind =
    * as it does in the side panel, subject to the configured mode.
    */
   | 'agent-prompt'
+  /**
+   * Runs a stored workflow graph via the workflow engine.
+   */
+  | 'workflow'
 
 /** A configured task. */
 export interface ScheduledTask {
@@ -41,6 +45,8 @@ export interface ScheduledTask {
   kind: TaskKind
   /** Used when `kind === 'agent-prompt'`. */
   prompt?: string
+  /** Used when `kind === 'workflow'`: the stored workflow to execute. */
+  workflowId?: string
   /**
    * Per-task cap on model↔tool round trips for agent-prompt tasks. Scheduled
    * tasks run unattended in full-auto and can need more steps than an

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -22,6 +22,7 @@ import type {
   Skill,
   UserProfile,
 } from './types'
+import type { Workflow, WorkflowEdge, WorkflowNode, WorkflowSettings } from './workflow/types'
 
 const KEY_SCHEMA = 'schemaVersion'
 const KEY_SETTINGS = 'settings'
@@ -643,6 +644,7 @@ function asHistory(value: unknown): HistoryEntry | null {
     detail: Array.isArray(entry.detail)
       ? entry.detail.filter((d): d is string => typeof d === 'string')
       : undefined,
+    ...(entry.args && typeof entry.args === 'object' ? { args: entry.args } : {}),
   }
 }
 
@@ -673,4 +675,217 @@ export async function deleteHistory(id: string): Promise<void> {
 
 export async function clearHistory(): Promise<void> {
   await chrome.storage.local.set({ [KEY_HISTORY]: [] })
+}
+
+// --- Rebuild workflows from action history ----------------------------------
+
+const DEFAULT_WF_SETTINGS: WorkflowSettings = {
+  saveLog: false,
+  debugMode: false,
+  notification: false,
+  reuseLastState: false,
+}
+
+/** Agent tool action → workflow block id. Actions without a block are skipped. */
+const ACTION_TO_BLOCK: Record<string, string> = {
+  open_url: 'open-url',
+  tab_new: 'new-tab',
+  tab_switch: 'switch-tab',
+  tab_close: 'close-tab',
+  click: 'click',
+  fill: 'fill',
+  select_option: 'select-option',
+  set_checkbox: 'set-checkbox',
+  press_key: 'press-key',
+  scroll: 'scroll',
+  wait_for: 'wait-for',
+}
+
+/**
+ * Best-effort CSS selector from an agent action's args. An explicit
+ * `selector` wins when present. Otherwise a rich `TargetSpec`'s `primary` is
+ * re-expressed into a CSS selector when it maps cleanly:
+ *   - `how: 'css'`    → the raw selector
+ *   - `how: 'id'`     → `#<value>`
+ *   - `how: 'name'`   → `[name="<value>"]`
+ *   - `how: 'testid'` → `[data-testid="<value>"]`
+ *   - `how: 'tag'`    → the tag name (optionally scoped by `nth`)
+ * `role`/`text` targets can't be safely turned into a plain CSS selector
+ * without knowing the page, so they yield `''` (the user fills them in).
+ */
+function selectorFromArgs(args: Record<string, unknown> | undefined): string {
+  if (!args || typeof args !== 'object') return ''
+  if (typeof args.selector === 'string' && args.selector.trim()) return args.selector.trim()
+  const target = args.target as
+    | { primary?: { how?: string; value?: unknown; tag?: string; nth?: number } }
+    | undefined
+  const primary = target?.primary
+  if (!primary) return ''
+  const nth = typeof primary.nth === 'number' && primary.nth > 0 ? `:nth-of-type(${primary.nth + 1})` : ''
+  const value = primary.value
+  switch (primary.how) {
+    case 'css':
+      return typeof value === 'string' ? value.trim() : ''
+    case 'id':
+      return typeof value === 'string' && value.trim() ? `#${value.trim()}` : ''
+    case 'name':
+      return typeof value === 'string' && value.trim() ? `[name="${value.trim()}"]${nth}` : ''
+    case 'testid':
+      return typeof value === 'string' && value.trim()
+        ? `[data-testid="${value.trim()}"]${nth}`
+        : ''
+    case 'tag':
+      return typeof primary.tag === 'string' && primary.tag.trim()
+        ? `${primary.tag.trim()}${nth}`
+        : ''
+    default:
+      // role / text — cannot be expressed as a stable CSS selector.
+      return ''
+  }
+}
+
+/**
+ * Whether two consecutive history steps describe the same replayable action.
+ * Navigation with the same URL is always a duplicate; element actions are
+ * compared on the signature that actually matters for replay (selector + value).
+ */
+function sameStep(
+  a: { action: string; args: Record<string, unknown> | undefined },
+  b: { action: string; args: Record<string, unknown> | undefined },
+): boolean {
+  if (a.action !== b.action) return false
+  switch (a.action) {
+    case 'open_url':
+    case 'tab_new':
+      return String(a.args?.url ?? '') === String(b.args?.url ?? '')
+    case 'tab_switch':
+      return Number(a.args?.index ?? 0) === Number(b.args?.index ?? 0)
+    case 'tab_close':
+      return true
+    case 'press_key':
+      return String(a.args?.key ?? '') === String(b.args?.key ?? '')
+    case 'click':
+    case 'hover':
+      return selectorFromArgs(a.args) !== '' && selectorFromArgs(a.args) === selectorFromArgs(b.args)
+    case 'fill':
+    case 'select_option':
+      return (
+        selectorFromArgs(a.args) === selectorFromArgs(b.args) &&
+        String(a.args?.value ?? '') === String(b.args?.value ?? '')
+      )
+    case 'set_checkbox':
+      return (
+        selectorFromArgs(a.args) === selectorFromArgs(b.args) &&
+        a.args?.value === b.args?.value
+      )
+    case 'scroll':
+      return (
+        String(a.args?.mode ?? 'into_view') === String(b.args?.mode ?? 'into_view') &&
+        Number(a.args?.x ?? 0) === Number(b.args?.x ?? 0) &&
+        Number(a.args?.y ?? 0) === Number(b.args?.y ?? 0) &&
+        selectorFromArgs(a.args) === selectorFromArgs(b.args)
+      )
+    default:
+      return false
+  }
+}
+
+/** Builds block values for a mapped tool action, best-effort from its args. */
+function valuesFromArgs(action: string, args: Record<string, unknown> | undefined): Record<string, unknown> {
+  const selector = selectorFromArgs(args)
+  switch (action) {
+    case 'open_url':
+    case 'tab_new':
+      return { url: typeof args?.url === 'string' ? args.url : '' }
+    case 'tab_switch':
+      return { index: Number(args?.index ?? 0) }
+    case 'tab_close':
+      return {}
+    case 'click':
+      return { cssSelector: selector }
+    case 'fill':
+      return { cssSelector: selector, value: typeof args?.value === 'string' ? args.value : '' }
+    case 'select_option':
+      return { cssSelector: selector, value: typeof args?.value === 'string' ? args.value : '' }
+    case 'set_checkbox':
+      return { cssSelector: selector, checked: args?.value !== false }
+    case 'press_key':
+      return { key: typeof args?.key === 'string' ? args.key : '' }
+    case 'scroll':
+      return {
+        mode: typeof args?.mode === 'string' ? args.mode : 'into_view',
+        cssSelector: selector,
+        ...(typeof args?.y === 'number' ? { y: args.y } : {}),
+      }
+    case 'wait_for':
+      return { cssSelector: selector, timeout: Number(args?.timeout ?? 5000) }
+    default:
+      return {}
+  }
+}
+
+/**
+ * Turns an ordered list of action-history entries (oldest first) into a linear
+ * workflow of mapped browser/navigation steps. Entries with no mapped block are
+ * skipped. Back-to-back identical steps (same action + same effective args) are
+ * collapsed to one node — the model occasionally re-issues the same navigation
+ * or action after a re-read, and a replayable workflow shouldn't repeat them.
+ * Returns `null` when nothing could be mapped.
+ */
+export function workflowFromHistory(entries: HistoryEntry[], name: string): Workflow | null {
+  const mapped = entries
+    .filter((e) => !!ACTION_TO_BLOCK[e.action])
+    .map((e) => ({ action: e.action, args: e.args }))
+
+  // Collapse consecutive steps that are effectively the same. For navigation
+  // (open_url/tab_new) a repeat with the same URL is always redundant — the
+  // page is already there. For element actions we compare a stable signature
+  // (action + selector + value/key) so two clicks on the same button in a row
+  // only become one block, while clicks on different targets are both kept.
+  const steps: typeof mapped = []
+  for (const step of mapped) {
+    const prev = steps[steps.length - 1]
+    if (prev && sameStep(prev, step)) continue
+    steps.push(step)
+  }
+  if (steps.length === 0) return null
+
+  const nodes: WorkflowNode[] = []
+  const edges: WorkflowEdge[] = []
+
+  // Trigger node — the first node in the graph, matching automa's convention.
+  // `label` holds the block id (same as data.blockId); the editor resolves the
+  // localized display name from the block registry at render time.
+  const triggerId = newId()
+  nodes.push({
+    id: triggerId,
+    label: 'manual',
+    position: { x: 160, y: 0 },
+    data: { blockId: 'manual', values: {} },
+  })
+  let prevId: string = triggerId
+
+  for (let i = 0; i < steps.length; i += 1) {
+    const step = steps[i]
+    if (!step) continue
+    const id = newId()
+    nodes.push({
+      id,
+      label: ACTION_TO_BLOCK[step.action]!,
+      position: { x: 160, y: 80 + i * 140 },
+      data: { blockId: ACTION_TO_BLOCK[step.action], values: valuesFromArgs(step.action, step.args) },
+    })
+    edges.push({ id: newId(), source: prevId, target: id })
+    prevId = id
+  }
+
+  return {
+    id: newId(),
+    name: name.trim() || 'From history',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    drawflow: { nodes, edges, position: { x: 0, y: 0 }, zoom: 1 },
+    trigger: { type: 'manual', enabled: true },
+    settings: { ...DEFAULT_WF_SETTINGS },
+  }
 }

--- a/src/lib/task-store.ts
+++ b/src/lib/task-store.ts
@@ -40,7 +40,7 @@ function asTask(value: unknown): ScheduledTask | null {
   const v = value as Partial<ScheduledTask>
   if (typeof v.id !== 'string' || typeof v.name !== 'string') return null
   const kind: TaskKind =
-    v.kind === 'github-review-requests' || v.kind === 'agent-prompt' ? v.kind : 'agent-prompt'
+    v.kind === 'workflow' ? 'workflow' : v.kind === 'github-review-requests' || v.kind === 'agent-prompt' ? v.kind : 'agent-prompt'
   return {
     id: v.id,
     name: v.name || 'Task',
@@ -48,6 +48,7 @@ function asTask(value: unknown): ScheduledTask | null {
     schedule: normalizeSchedule(v.schedule),
     kind,
     prompt: typeof v.prompt === 'string' ? v.prompt : undefined,
+    workflowId: typeof v.workflowId === 'string' ? v.workflowId : undefined,
     maxToolRounds: coerceMaxToolRounds(v.maxToolRounds),
     notifyFeishu: v.notifyFeishu === true,
     createdAt: typeof v.createdAt === 'number' ? v.createdAt : Date.now(),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -207,6 +207,11 @@ export interface HistoryEntry {
    * or the URL opened. One detail per array element, shown as sub-lines.
    */
   detail?: string[]
+  /**
+   * The raw tool args for this action. Retained so a full-auto session can be
+   * rebuilt into a workflow afterwards.
+   */
+  args?: Record<string, unknown>
 }
 
 /**

--- a/src/lib/workflow/interpolate.ts
+++ b/src/lib/workflow/interpolate.ts
@@ -1,0 +1,54 @@
+/**
+ * Template interpolation for workflow blocks.
+ *
+ * Blocks can reference live values in their parameter text using `{{name}}`
+ * tokens, e.g. `{{userName}}` or `{{row.email}}`, so the same workflow can
+ * adapt to the data it runs against. Kept as pure string logic (no chrome /
+ * storage dependency) so it is trivially testable.
+ *
+ * @module lib/workflow/interpolate
+ */
+
+const TOKEN = /\{\{\s*([^{}]+?)\s*\}\}/g
+
+/**
+ * Walk a dot-separated `path` (e.g. `a.b.0`) across nested objects / arrays.
+ * Returns `undefined` for any missing segment or a non-object step.
+ */
+export function getByPath(root: unknown, path: string): unknown {
+  let cursor = root
+  for (const segment of path.split('.')) {
+    if (cursor === null || cursor === undefined || typeof cursor !== 'object') {
+      return undefined
+    }
+    cursor = (cursor as Record<string, unknown>)[segment]
+  }
+  return cursor
+}
+
+/**
+ * Replace every `{{name}}` / `{{name.key}}` token in `text`.
+ *
+ * - `name` is resolved against `vars`, except the special key `refData` which
+ *   resolves to the `refData` value itself (its nested keys work too).
+ * - Function and object values are stringified via their `toString`.
+ * - Tokens that don't match anything are left in the text unchanged.
+ */
+export function interpolate(
+  text: string,
+  vars: Record<string, unknown>,
+  refData?: unknown,
+): string {
+  return text.replace(TOKEN, (whole, expression: string) => {
+    const expr = expression.trim()
+    if (expr === '') return whole
+    const dot = expr.indexOf('.')
+    const name = dot === -1 ? expr : expr.slice(0, dot)
+    const rest = dot === -1 ? '' : expr.slice(dot + 1)
+
+    const root = name === 'refData' ? refData : vars[name]
+    const value = rest === '' ? root : getByPath(root, rest)
+    if (value === undefined) return whole
+    return typeof value === 'function' ? value.toString() : String(value)
+  })
+}

--- a/src/lib/workflow/registry.ts
+++ b/src/lib/workflow/registry.ts
@@ -1,0 +1,761 @@
+/**
+ * Block registry (palette metadata): the MVP set of installable workflow
+ * blocks, grouped by category.
+ *
+ * Pure data — no `chrome` dependency — so it can be imported freely by the
+ * editor UI, the palette, and the executor registry without pulling in any
+ * runtime environment.
+ *
+ * @module lib/workflow/registry
+ */
+
+import type { BlockCategory, BlockDefinition } from './types'
+
+/** The six palette categories, in display order. */
+export const BLOCK_CATEGORIES: BlockCategory[] = [
+  'browser',
+  'navigation',
+  'data',
+  'control-flow',
+  'integration',
+  'trigger',
+]
+
+/**
+ * The MVP block templates. Every block id is unique and matches the key the
+ * execution engine dispatches on (`background/workflow-engine/executors.ts`).
+ */
+export const WORKFLOW_BLOCKS: BlockDefinition[] = [
+  // --- Browser ---------------------------------------------------------------
+  {
+    id: 'click',
+    category: 'browser',
+    label: '点击元素',
+    description: '点击匹配 CSS 选择器的元素。',
+    params: [
+      { name: 'cssSelector', label: 'CSS 选择器', type: 'string', required: true },
+    ],
+  },
+  {
+    id: 'fill',
+    category: 'browser',
+    label: '填写输入',
+    description: '向匹配 CSS 选择器的输入框填写文本。',
+    params: [
+      { name: 'cssSelector', label: 'CSS 选择器', type: 'string', required: true },
+      { name: 'value', label: '填写内容', type: 'string', required: true },
+    ],
+  },
+  {
+    id: 'select-option',
+    category: 'browser',
+    label: '选择下拉项',
+    description: '在下拉列表中选择指定选项。',
+    params: [
+      { name: 'cssSelector', label: 'CSS 选择器', type: 'string', required: true },
+      { name: 'value', label: '选项值', type: 'string', required: true },
+    ],
+  },
+  {
+    id: 'scroll',
+    category: 'browser',
+    label: '滚动页面',
+    description: '滚动到页面顶部/底部/指定偏移，或按增量平滑滚动，也可将元素滚入视野。',
+    params: [
+      {
+        name: 'mode',
+        label: '滚动方式',
+        type: 'select',
+        default: 'into_view',
+        options: ['into_view', 'top', 'bottom', 'by', 'incremental'],
+      },
+      { name: 'cssSelector', label: 'CSS 选择器', type: 'string' },
+      { name: 'x', label: '横向偏移', type: 'number', default: 0 },
+      { name: 'y', label: '纵向偏移', type: 'number', default: 0 },
+      {
+        name: 'scrollBehavior',
+        label: '滚动行为',
+        type: 'select',
+        default: 'auto',
+        options: ['auto', 'smooth'],
+      },
+      {
+        name: 'step',
+        label: '每次步长(px)',
+        type: 'number',
+        default: 120,
+        description: 'incremental 模式下每次滚动的距离',
+      },
+    ],
+  },
+  {
+    id: 'press-key',
+    category: 'browser',
+    label: '按下按键',
+    description: '在当前页面模拟一次键盘按键（如 Enter、Tab）。',
+    params: [{ name: 'key', label: '按键', type: 'string', required: true }],
+  },
+  {
+    id: 'wait-for',
+    category: 'browser',
+    label: '等待元素',
+    description: '等待匹配 CSS 选择器的元素出现。',
+    params: [
+      { name: 'cssSelector', label: 'CSS 选择器', type: 'string', required: true },
+      { name: 'timeout', label: '超时(ms)', type: 'number', default: 5000 },
+    ],
+  },
+  {
+    id: 'take-screenshot',
+    category: 'browser',
+    label: '截图',
+    description: '截取可见区域、整个页面或指定元素，结果存入变量。',
+    params: [
+      {
+        name: 'type',
+        label: '截图类型',
+        type: 'select',
+        default: 'page',
+        options: ['page', 'fullpage', 'element'],
+      },
+      { name: 'cssSelector', label: 'CSS 选择器', type: 'string' },
+      { name: 'variableName', label: '变量名', type: 'string', default: 'lastScreenshot' },
+    ],
+  },
+  {
+    id: 'get-text',
+    category: 'browser',
+    label: '读取文本',
+    description: '读取第一个匹配 CSS 选择器元素的文本，存入变量 lastText。',
+    params: [{ name: 'cssSelector', label: 'CSS 选择器', type: 'string', required: true }],
+  },
+  {
+    id: 'hover',
+    category: 'browser',
+    label: '悬停元素',
+    description: '将鼠标悬停在匹配 CSS 选择器的元素上。',
+    params: [
+      { name: 'cssSelector', label: 'CSS 选择器', type: 'string', required: true },
+    ],
+  },
+  {
+    id: 'set-checkbox',
+    category: 'browser',
+    label: '设置复选框',
+    description: '勾选或取消勾选匹配 CSS 选择器的复选框。',
+    params: [
+      { name: 'cssSelector', label: 'CSS 选择器', type: 'string', required: true },
+      { name: 'checked', label: '勾选', type: 'boolean', default: true },
+    ],
+  },
+  {
+    id: 'set-radio',
+    category: 'browser',
+    label: '选择单选项',
+    description: '选中匹配 CSS 选择器的单选按钮。',
+    params: [{ name: 'cssSelector', label: 'CSS 选择器', type: 'string', required: true }],
+  },
+  {
+    id: 'get-form',
+    category: 'browser',
+    label: '读取表单',
+    description: '读取表单中所有输入项的值，存入变量。可选 cssSelector 限定范围。',
+    params: [
+      { name: 'variableName', label: '变量名', type: 'string', default: 'lastForm' },
+      { name: 'cssSelector', label: 'CSS 选择器(可选)', type: 'string' },
+    ],
+  },
+
+  // --- Browser actions (automa-aligned) ------------------------------------
+  {
+    id: 'cookie',
+    category: 'browser',
+    label: 'Cookie',
+    description: '读取/写入/删除浏览器 Cookie，结果存入变量。',
+    params: [
+      {
+        name: 'op',
+        label: '操作',
+        type: 'select',
+        default: 'get',
+        options: ['get', 'set', 'remove', 'getAll'],
+      },
+      { name: 'name', label: 'Cookie 名', type: 'string' },
+      { name: 'value', label: '值', type: 'string' },
+      { name: 'url', label: 'URL', type: 'string' },
+      { name: 'variableName', label: '变量名', type: 'string', default: 'lastCookie' },
+    ],
+  },
+  {
+    id: 'clipboard',
+    category: 'browser',
+    label: '剪贴板',
+    description: '读取或写入系统剪贴板文本（经 offscreen 页面）。',
+    params: [
+      {
+        name: 'op',
+        label: '操作',
+        type: 'select',
+        default: 'get',
+        options: ['get', 'insert'],
+      },
+      { name: 'text', label: '文本', type: 'string' },
+      { name: 'variableName', label: '变量名', type: 'string', default: 'lastClipboard' },
+    ],
+  },
+  {
+    id: 'element-exists',
+    category: 'browser',
+    label: '元素是否存在',
+    description: '按 CSS 选择器判断元素是否存在，按 exists / notExists 分支流转。',
+    params: [{ name: 'cssSelector', label: 'CSS 选择器', type: 'string', required: true }],
+    outputs: [
+      { id: 'exists', label: '存在', type: 'source' },
+      { id: 'notExists', label: '不存在', type: 'source' },
+    ],
+  },
+  {
+    id: 'link',
+    category: 'browser',
+    label: '打开链接',
+    description: '打开匹配 CSS 选择器的链接，可控制是否在新标签页打开。',
+    params: [
+      { name: 'cssSelector', label: 'CSS 选择器', type: 'string', required: true },
+      { name: 'newTab', label: '新标签页打开', type: 'boolean', default: true },
+    ],
+  },
+  {
+    id: 'attribute-value',
+    category: 'browser',
+    label: '属性值',
+    description: '读取或写入元素属性值，结果存入变量。',
+    params: [
+      {
+        name: 'op',
+        label: '操作',
+        type: 'select',
+        default: 'get',
+        options: ['get', 'set'],
+      },
+      { name: 'cssSelector', label: 'CSS 选择器', type: 'string', required: true },
+      { name: 'attribute', label: '属性名', type: 'string', required: true },
+      { name: 'value', label: '属性值', type: 'string' },
+      { name: 'variableName', label: '变量名', type: 'string', default: 'lastAttribute' },
+    ],
+  },
+  {
+    id: 'go-back',
+    category: 'navigation',
+    label: '后退',
+    description: '在活动标签页执行浏览器后退。',
+    params: [],
+  },
+  {
+    id: 'forward-page',
+    category: 'navigation',
+    label: '前进',
+    description: '在活动标签页执行浏览器前进。',
+    params: [],
+  },
+  {
+    id: 'tab-url',
+    category: 'navigation',
+    label: '标签页地址',
+    description: '读取活动标签页或全部标签页的 URL。',
+    params: [
+      {
+        name: 'scope',
+        label: '范围',
+        type: 'select',
+        default: 'active',
+        options: ['active', 'all'],
+      },
+      { name: 'variableName', label: '变量名', type: 'string', default: 'lastTabUrl' },
+    ],
+  },
+  {
+    id: 'active-tab',
+    category: 'navigation',
+    label: '活动标签页',
+    description: '读取活动标签页的信息（标题、URL）。',
+    params: [{ name: 'variableName', label: '变量名', type: 'string', default: 'lastActiveTab' }],
+  },
+  {
+    id: 'new-window',
+    category: 'navigation',
+    label: '新建窗口',
+    description: '打开一个新的浏览器窗口。',
+    params: [{ name: 'url', label: '网址(可选)', type: 'string' }],
+  },
+  {
+    id: 'create-element',
+    category: 'browser',
+    label: '创建元素',
+    description: '在页面中注入一段 HTML。',
+    params: [{ name: 'html', label: 'HTML', type: 'string', required: true }],
+  },
+  {
+    id: 'upload-file',
+    category: 'browser',
+    label: '上传文件',
+    description: '向文件输入框填入 data-url，模拟上传文件。',
+    params: [
+      { name: 'cssSelector', label: 'CSS 选择器', type: 'string', required: true },
+      { name: 'fileData', label: '文件 Data-URL', type: 'string', required: true },
+    ],
+  },
+  {
+    id: 'handle-dialog',
+    category: 'browser',
+    label: '处理弹窗',
+    description: '自动确认或解除页面弹出对话框。',
+    params: [],
+  },
+
+  // --- Navigation ------------------------------------------------------------
+  {
+    id: 'open-url',
+    category: 'navigation',
+    label: '打开网址',
+    description: '在当前标签页导航到指定网址（仅 http/https）。',
+    params: [{ name: 'url', label: '网址', type: 'string', required: true }],
+  },
+  {
+    id: 'new-tab',
+    category: 'navigation',
+    label: '新建标签页',
+    description: '在新标签页中打开一个网址（仅 http/https）。',
+    params: [{ name: 'url', label: '网址', type: 'string', required: true }],
+  },
+  {
+    id: 'switch-tab',
+    category: 'navigation',
+    label: '切换标签页',
+    description: '按索引切换到本窗口中的另一个标签页。',
+    params: [{ name: 'index', label: '标签页索引', type: 'number', default: 0 }],
+  },
+  {
+    id: 'close-tab',
+    category: 'navigation',
+    label: '关闭标签页',
+    description: '关闭当前活动标签页。',
+    params: [],
+  },
+  {
+    id: 'reload-tab',
+    category: 'navigation',
+    label: '刷新标签页',
+    description: '刷新当前活动标签页。',
+    params: [],
+  },
+
+  // --- Data ------------------------------------------------------------------
+  {
+    id: 'set-variable',
+    category: 'data',
+    label: '设置变量',
+    description: '把值存入工作流变量。',
+    params: [
+      { name: 'variableName', label: '变量名', type: 'string', required: true },
+      { name: 'value', label: '值', type: 'string', required: true },
+    ],
+  },
+  {
+    id: 'get-variable',
+    category: 'data',
+    label: '读取变量',
+    description: '读取工作流变量的值。',
+    params: [{ name: 'variableName', label: '变量名', type: 'string', required: true }],
+  },
+  {
+    id: 'insert-data',
+    category: 'data',
+    label: '插入数据',
+    description: '向数据表新增一行（JSON）。',
+    params: [{ name: 'data', label: '数据(JSON)', type: 'json', required: true }],
+  },
+  {
+    id: 'export-data',
+    category: 'data',
+    label: '导出数据',
+    description: '把数据表导出为 CSV 或 JSON。',
+    params: [
+      {
+        name: 'format',
+        label: '导出格式',
+        type: 'select',
+        default: 'json',
+        options: ['csv', 'json'],
+      },
+    ],
+  },
+  {
+    id: 'increase-variable',
+    category: 'data',
+    label: '变量递增/乘算',
+    description: '对数字变量做加法或乘法并写回。',
+    params: [
+      { name: 'variableName', label: '变量名', type: 'string', required: true },
+      { name: 'value', label: '值', type: 'number', default: 1 },
+      {
+        name: 'incType',
+        label: '类型',
+        type: 'select',
+        default: 'add',
+        options: ['add', 'multiply'],
+      },
+    ],
+  },
+  {
+    id: 'slice-variable',
+    category: 'data',
+    label: '变量切片',
+    description: '对字符串或数组按起止下标切片。',
+    params: [
+      { name: 'variableName', label: '变量名', type: 'string', required: true },
+      { name: 'start', label: '起始', type: 'number', default: 0 },
+      { name: 'end', label: '结束(可选)', type: 'number' },
+      { name: 'output', label: '输出变量名', type: 'string' },
+    ],
+  },
+  {
+    id: 'regex-variable',
+    category: 'data',
+    label: '正则处理变量',
+    description: '对变量做正则匹配或替换。',
+    params: [
+      { name: 'variableName', label: '变量名', type: 'string', required: true },
+      { name: 'pattern', label: '正则', type: 'string', required: true },
+      { name: 'flags', label: '标志', type: 'string', default: 'g' },
+      { name: 'operation', label: '操作', type: 'select', default: 'match', options: ['match', 'replace'] },
+      { name: 'replace', label: '替换串', type: 'string' },
+      { name: 'output', label: '输出变量名', type: 'string' },
+    ],
+  },
+  {
+    id: 'delete-data',
+    category: 'data',
+    label: '删除数据行',
+    description: '按下标删除数据表的一行，或清空数据表。',
+    params: [
+      { name: 'key', label: '行下标', type: 'number', default: -1 },
+      { name: 'clearAll', label: '清空全部', type: 'boolean', default: false },
+    ],
+  },
+  {
+    id: 'sort-data',
+    category: 'data',
+    label: '排序数据',
+    description: '按字段升序或降序排列数据表。',
+    params: [
+      { name: 'field', label: '字段', type: 'string' },
+      { name: 'direction', label: '方向', type: 'select', default: 'asc', options: ['asc', 'desc'] },
+    ],
+  },
+  {
+    id: 'data-mapping',
+    category: 'data',
+    label: '映射数据',
+    description: '对数据表每行应用 JS 表达式，结果存入变量。表达式字段为 mapping。',
+    params: [
+      { name: 'mapping', label: 'JS 表达式', type: 'string', required: true },
+      { name: 'output', label: '输出变量名', type: 'string' },
+    ],
+  },
+  {
+    id: 'log-data',
+    category: 'data',
+    label: '记录日志',
+    description: '把一段文本写入运行日志。',
+    params: [{ name: 'text', label: '文本', type: 'string' }],
+  },
+  {
+    id: 'workflow-state',
+    category: 'data',
+    label: '工作流状态',
+    description: '读取或写入一个工作流状态变量。',
+    params: [
+      {
+        name: 'op',
+        label: '操作',
+        type: 'select',
+        default: 'get',
+        options: ['get', 'set'],
+      },
+      { name: 'variableName', label: '变量名', type: 'string', default: 'state' },
+      { name: 'value', label: '值', type: 'string' },
+    ],
+  },
+
+  // --- Control flow ----------------------------------------------------------
+  {
+    id: 'condition',
+    category: 'control-flow',
+    label: '条件判断',
+    description: '按 JS 表达式的结果选择执行路径。表达式字段名为 code。',
+    params: [{ name: 'code', label: 'JS 表达式', type: 'string', required: true }],
+  },
+  {
+    id: 'loop-data',
+    category: 'control-flow',
+    label: '遍历数据',
+    description: '遍历一项数据（JSON 字符串），逐行执行后续步骤。',
+    params: [{ name: 'data', label: '数据(JSON)', type: 'json', required: true }],
+  },
+  {
+    id: 'repeat-task',
+    category: 'control-flow',
+    label: '重复执行',
+    description: '将后续步骤固定重复指定次数。',
+    params: [{ name: 'count', label: '重复次数', type: 'number', default: 1 }],
+  },
+  {
+    id: 'while-loop',
+    category: 'control-flow',
+    label: '条件循环',
+    description: '当 JS 表达式为真时反复执行后续步骤。表达式字段为 code。',
+    params: [{ name: 'code', label: 'JS 表达式', type: 'string', required: true }],
+  },
+  {
+    id: 'loop-elements',
+    category: 'control-flow',
+    label: '遍历页面元素',
+    description: '按 CSS 选择器遍历页面中的元素，逐元素执行后续步骤，暴露 loopIndex。',
+    params: [{ name: 'cssSelector', label: 'CSS 选择器', type: 'string', required: true }],
+  },
+  {
+    id: 'delay',
+    category: 'control-flow',
+    label: '延时',
+    description: '暂停指定毫秒数。',
+    params: [{ name: 'ms', label: '毫秒', type: 'number', default: 500 }],
+  },
+  {
+    id: 'breakpoint',
+    category: 'control-flow',
+    label: '断点',
+    description: '暂停执行，供调试时检查变量状态。',
+    params: [],
+  },
+
+  // --- Integration -----------------------------------------------------------
+  {
+    id: 'webhook',
+    category: 'integration',
+    label: '发送 Webhook / HTTP 请求',
+    description: '向指定 URL 发起 HTTP 请求，支持 method/headers/body/timeout，响应存入变量。',
+    params: [
+      { name: 'url', label: '请求 URL', type: 'string', required: true },
+      {
+        name: 'method',
+        label: '请求方法',
+        type: 'select',
+        default: 'POST',
+        options: ['POST', 'GET', 'PUT', 'PATCH', 'DELETE', 'HEAD'],
+      },
+      { name: 'headers', label: '请求头(JSON)', type: 'json', default: '{}' },
+      { name: 'body', label: '请求体(JSON)', type: 'json', default: '{}' },
+      { name: 'timeout', label: '超时(ms)', type: 'number', default: '30000' },
+      { name: 'responseVariable', label: '响应变量名', type: 'string', default: 'lastHttpResponse' },
+    ],
+  },
+  {
+    id: 'notification',
+    category: 'integration',
+    label: '发送通知',
+    description: '发送一条浏览器桌面通知。',
+    params: [
+      { name: 'title', label: '标题', type: 'string', required: true },
+      { name: 'body', label: '内容', type: 'string' },
+    ],
+  },
+  {
+    id: 'javascript-code',
+    category: 'integration',
+    label: 'JavaScript 代码',
+    description: '在沙箱中执行一段自定义 JavaScript。',
+    params: [{ name: 'code', label: '代码', type: 'string', required: true }],
+  },
+  {
+    id: 'ai-prompt',
+    category: 'integration',
+    label: '调用 AI',
+    description: '在本步骤调用模型并返回文本结果。',
+    params: [{ name: 'prompt', label: '提示词', type: 'string', required: true }],
+  },
+  {
+    id: 'execute-workflow',
+    category: 'integration',
+    label: '执行子工作流',
+    description: '作为子例程调用另一个工作流。',
+    params: [{ name: 'workflowId', label: '工作流 ID', type: 'string', required: true }],
+  },
+  {
+    id: 'parameter-prompt',
+    category: 'integration',
+    label: '参数提示',
+    description: '声明一个需要输入/预置的参数变量。',
+    params: [
+      { name: 'variableName', label: '变量名', type: 'string', default: 'userInput' },
+      { name: 'prompt', label: '提示', type: 'string', default: '请输入值' },
+      { name: 'defaultValue', label: '默认值', type: 'string' },
+    ],
+  },
+  {
+    id: 'switch-to',
+    category: 'integration',
+    label: '切换 iframe',
+    description: '指定后续操作的目标 iframe（驱动端已全框架搜索）。',
+    params: [{ name: 'frameSelector', label: 'iframe 选择器', type: 'string' }],
+  },
+  {
+    id: 'trigger-event',
+    category: 'browser',
+    label: '触发事件',
+    description: '在匹配元素上触发一个 DOM 事件，可携带 detail 数据。',
+    params: [
+      { name: 'cssSelector', label: 'CSS 选择器', type: 'string', required: true },
+      { name: 'event', label: '事件名', type: 'string', required: true },
+      { name: 'detail', label: 'detail(JSON)', type: 'string', default: 'null' },
+    ],
+  },
+  {
+    id: 'browser-event',
+    category: 'integration',
+    label: '页面事件监听',
+    description: '监听页面事件（需常驻 content script，当前为占位）。',
+    params: [{ name: 'eventName', label: '事件名', type: 'string' }],
+  },
+  {
+    id: 'handle-download',
+    category: 'integration',
+    label: '处理下载',
+    description: '查找最近匹配的下载项，结果存入变量。',
+    params: [
+      { name: 'filename', label: '文件名包含', type: 'string' },
+      { name: 'variableName', label: '变量名', type: 'string', default: 'lastDownload' },
+    ],
+  },
+  {
+    id: 'save-assets',
+    category: 'integration',
+    label: '保存资源',
+    description: '把资源保存到工作区目标（需目标配置，当前为占位）。',
+    params: [],
+  },
+  {
+    id: 'proxy',
+    category: 'integration',
+    label: '设置代理',
+    description: '配置浏览器代理（需浏览器级设置，当前为占位）。',
+    params: [{ name: 'server', label: '代理地址', type: 'string' }],
+  },
+  {
+    id: 'google-sheets',
+    category: 'integration',
+    label: 'Google 表格',
+    description: '读写 Google Sheets（需要 OAuth 凭据，当前为占位）。',
+    params: [{ name: 'spreadsheetId', label: '表格 ID', type: 'string' }],
+  },
+  {
+    id: 'google-drive',
+    category: 'integration',
+    label: 'Google 云盘',
+    description: '读写 Google Drive（需要 OAuth 凭据，当前为占位）。',
+    params: [{ name: 'fileId', label: '文件 ID', type: 'string' }],
+  },
+  {
+    id: 'wait-connections',
+    category: 'integration',
+    label: '等待网络连接',
+    description: '等待页面网络连接空闲（当前为占位）。',
+    params: [],
+  },
+  {
+    id: 'note',
+    category: 'integration',
+    label: '备注',
+    description: '在流程中加入一条说明性备注。',
+    params: [{ name: 'text', label: '备注内容', type: 'string' }],
+  },
+  {
+    id: 'blocks-group',
+    category: 'integration',
+    label: '块分组',
+    description: '将一组块组织成一个容器（结构性）。',
+    params: [],
+  },
+
+  // --- Trigger ---------------------------------------------------------------
+  {
+    id: 'visit-web',
+    category: 'trigger',
+    label: '访问网址',
+    description: '当访问匹配的网址时运行工作流。',
+    params: [{ name: 'urlPattern', label: 'URL 匹配(正则)', type: 'string' }],
+  },
+  {
+    id: 'schedule',
+    category: 'trigger',
+    label: '定时运行',
+    description: '在设定的时间或间隔运行工作流。',
+    params: [{ name: 'cron', label: '时间表达式', type: 'string' }],
+  },
+  {
+    id: 'manual',
+    category: 'trigger',
+    label: '手动运行',
+    description: '在列表中手动触发工作流。',
+    params: [],
+  },
+  {
+    id: 'context-menu',
+    category: 'trigger',
+    label: '右键菜单',
+    description: '通过浏览器右键菜单触发工作流。',
+    params: [{ name: 'title', label: '菜单标题', type: 'string' }],
+  },
+  {
+    id: 'on-startup',
+    category: 'trigger',
+    label: '浏览器启动',
+    description: '浏览器启动时运行工作流。',
+    params: [],
+  },
+  {
+    id: 'keyboard-shortcut',
+    category: 'trigger',
+    label: '键盘快捷键',
+    description: '按快捷键时运行工作流。',
+    params: [{ name: 'shortcut', label: '快捷键', type: 'string', default: 'Ctrl+Shift+Y' }],
+  },
+  {
+    id: 'date',
+    category: 'trigger',
+    label: '日期触发',
+    description: '在指定时刻运行工作流。',
+    params: [{ name: 'time', label: '时刻(如 09:00)', type: 'string' }],
+  },
+  {
+    id: 'specific-day',
+    category: 'trigger',
+    label: '特定星期',
+    description: '在指定星期几运行工作流。',
+    params: [
+      { name: 'days', label: '星期(逗号分隔)', type: 'string', default: '1,2,3,4,5' },
+      { name: 'time', label: '时刻(如 09:00)', type: 'string' },
+    ],
+  },
+  {
+    id: 'element-change',
+    category: 'trigger',
+    label: '元素变化',
+    description: '页面元素发生变化时运行工作流（需常驻 content script）。',
+    params: [{ name: 'cssSelector', label: 'CSS 选择器', type: 'string' }],
+  },
+]
+
+/** Lookup from block id to its definition; ids are unique by construction. */
+export const BLOCK_BY_ID: Map<string, BlockDefinition> = new Map(
+  WORKFLOW_BLOCKS.map((block) => [block.id, block]),
+)

--- a/src/lib/workflow/storage.ts
+++ b/src/lib/workflow/storage.ts
@@ -1,0 +1,169 @@
+/**
+ * Persistence for workflows.
+ *
+ * Workflows live in `chrome.storage.local` under the single `'workflows'` key,
+ * mirroring the rest of the codebase (see `task-store.ts`). Kept in
+ * `lib/workflow/*` rather than shared `storage.ts` because workflows have their
+ * own schema and their own normalization rules; lumping them in would widen
+ * that already-busy module.
+ *
+ * @module lib/workflow/storage
+ */
+
+import { newId } from '../storage'
+import type {
+  Workflow,
+  WorkflowEdge,
+  WorkflowNode,
+  WorkflowSettings,
+} from './types'
+
+const KEY_WORKFLOWS = 'workflows'
+
+const DEFAULT_SETTINGS: WorkflowSettings = {
+  saveLog: false,
+  debugMode: false,
+  notification: false,
+  reuseLastState: false,
+}
+
+/**
+ * Normalizes a stored workflow value into the current shape, or returns `null`
+ * when the record is unusable (missing the id/name every workflow needs).
+ *
+ * Storage is shared with a user who may have downgraded or hit a half-written
+ * record, so every field is validated rather than trusted. Exported as a pure
+ * function so the rules are unit-testable without `chrome`.
+ */
+export function asWorkflow(value: unknown): Workflow | null {
+  if (!value || typeof value !== 'object') return null
+  const v = value as Partial<Workflow>
+  if (typeof v.id !== 'string' || typeof v.name !== 'string') return null
+
+  const rawDrawflow = (v.drawflow ?? {}) as {
+    nodes?: unknown
+    edges?: unknown
+    position?: unknown
+    zoom?: unknown
+  }
+  const nodes: WorkflowNode[] = Array.isArray(rawDrawflow.nodes)
+    ? rawDrawflow.nodes.filter(
+        (node): node is WorkflowNode =>
+          !!node &&
+          typeof node === 'object' &&
+          typeof (node as WorkflowNode).id === 'string' &&
+          typeof (node as WorkflowNode).label === 'string' &&
+          !!node &&
+          typeof (node as WorkflowNode).position === 'object' &&
+          typeof (node as WorkflowNode).position?.x === 'number' &&
+          typeof (node as WorkflowNode).position?.y === 'number',
+      )
+    : []
+  const edges: WorkflowEdge[] = Array.isArray(rawDrawflow.edges)
+    ? rawDrawflow.edges.filter(
+        (edge): edge is WorkflowEdge =>
+          !!edge &&
+          typeof edge === 'object' &&
+          typeof (edge as WorkflowEdge).id === 'string' &&
+          typeof (edge as WorkflowEdge).source === 'string' &&
+          typeof (edge as WorkflowEdge).target === 'string',
+      )
+    : []
+
+  const rawPosition = rawDrawflow.position
+  const position =
+    rawPosition && typeof rawPosition === 'object'
+      ? ((rawPosition as { x?: unknown; y?: unknown }).x === 'number' ||
+          (rawPosition as { x?: unknown; y?: unknown }).y === 'number'
+          ? (rawPosition as unknown as { x: number; y: number })
+          : undefined)
+      : undefined
+
+  const rawSettings = (v.settings ?? {}) as Partial<WorkflowSettings>
+  const settings: WorkflowSettings = {
+    ...DEFAULT_SETTINGS,
+    saveLog: rawSettings.saveLog === true,
+    debugMode: rawSettings.debugMode === true,
+    notification: rawSettings.notification === true,
+    reuseLastState: rawSettings.reuseLastState === true,
+    ...(typeof rawSettings.defaultColumnName === 'string'
+      ? { defaultColumnName: rawSettings.defaultColumnName }
+      : {}),
+  }
+
+  return {
+    id: v.id,
+    name: v.name || 'Workflow',
+    ...(typeof v.description === 'string' ? { description: v.description } : {}),
+    ...(typeof v.folderId === 'string' ? { folderId: v.folderId } : {}),
+    createdAt: typeof v.createdAt === 'number' ? v.createdAt : Date.now(),
+    updatedAt: typeof v.updatedAt === 'number' ? v.updatedAt : Date.now(),
+    drawflow: {
+      nodes,
+      edges,
+      ...(position ? { position } : {}),
+      ...(typeof rawDrawflow.zoom === 'number' ? { zoom: rawDrawflow.zoom } : {}),
+    },
+    settings,
+    ...(v.trigger && typeof v.trigger === 'object' && typeof v.trigger.type === 'string'
+      ? { trigger: v.trigger }
+      : {}),
+    ...(v.table !== undefined ? { table: v.table } : {}),
+  }
+}
+
+export async function listWorkflows(): Promise<Workflow[]> {
+  const stored = await chrome.storage.local.get(KEY_WORKFLOWS)
+  const list = stored[KEY_WORKFLOWS]
+  if (!Array.isArray(list)) return []
+  return list
+    .map(asWorkflow)
+    .filter((workflow): workflow is Workflow => workflow !== null)
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+}
+
+export async function getWorkflow(id: string): Promise<Workflow | undefined> {
+  return (await listWorkflows()).find((workflow) => workflow.id === id)
+}
+
+export async function saveWorkflow(workflow: Workflow): Promise<void> {
+  const list = await listWorkflows()
+  const normalized = asWorkflow({ ...workflow, updatedAt: Date.now() })
+  if (!normalized) throw new Error('Invalid workflow')
+  const index = list.findIndex((existing) => existing.id === workflow.id)
+  if (index >= 0) list[index] = normalized
+  else list.push(normalized)
+  await chrome.storage.local.set({ [KEY_WORKFLOWS]: list })
+}
+
+export async function deleteWorkflow(id: string): Promise<void> {
+  const list = await listWorkflows()
+  await chrome.storage.local.set({
+    [KEY_WORKFLOWS]: list.filter((workflow) => workflow.id !== id),
+  })
+}
+
+/**
+ * Creates a detached copy of an existing workflow under a fresh id.
+ *
+ * `newName` overrides the display name; otherwise `"<name> (copy)"` is used.
+ * Returns `undefined` when no workflow with `id` exists.
+ */
+export async function duplicateWorkflow(
+  id: string,
+  newName?: string,
+): Promise<Workflow | undefined> {
+  const source = await getWorkflow(id)
+  if (!source) return undefined
+  const now = Date.now()
+  const copy = asWorkflow({
+    ...JSON.parse(JSON.stringify(source)),
+    id: newId(),
+    name: newName?.trim() || `${source.name} (copy)`,
+    createdAt: now,
+    updatedAt: now,
+  })
+  if (!copy) return undefined
+  await saveWorkflow(copy)
+  return copy
+}

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -1,0 +1,147 @@
+/**
+ * Domain types for automatable workflows.
+ *
+ * A workflow is a node-graph of blocks (browser steps, data transforms,
+ * control flow, integrations, triggers) plus execution settings and the
+ * variables it operates on. Kept in its own `lib/workflow/*` namespace so the
+ * model, its validation rules, and its persistence stay together and separate
+ * from the scheduler / conversation stores.
+ *
+ * @module lib/workflow/types
+ */
+
+/** The broad category a block belongs to, used for palette grouping. */
+export type BlockCategory =
+  | 'browser'
+  | 'navigation'
+  | 'data'
+  | 'control-flow'
+  | 'integration'
+  | 'trigger'
+
+/** A connection point on a block, for wiring nodes together in the editor. */
+export interface HandleDefinition {
+  id: string
+  /** Human-readable name shown next to the handle. */
+  label?: string
+  /** Whether this handle receives or emits links. */
+  type?: 'source' | 'target'
+  /** Visual side of the node the handle sits on. */
+  position?: 'left' | 'right' | 'top' | 'bottom'
+}
+
+/** A configurable input for a block. */
+export interface ParamDefinition {
+  name: string
+  label?: string
+  type?: 'string' | 'number' | 'boolean' | 'select' | 'json'
+  /** Whether the user must fill this in for the block to run. */
+  required?: boolean
+  default?: unknown
+  description?: string
+  /** Choices when `type === 'select'`. */
+  options?: string[]
+}
+
+/** A reusable, palette-installable block template. */
+export interface BlockDefinition {
+  id: string
+  category: BlockCategory
+  label?: string
+  description?: string
+  inputs?: HandleDefinition[]
+  outputs?: HandleDefinition[]
+  params?: ParamDefinition[]
+}
+
+/** A node placed on the canvas. */
+export interface WorkflowNode {
+  id: string
+  label: string
+  position: { x: number; y: number }
+  /** Block-specific configuration, keyed by param name. */
+  data: Record<string, unknown>
+}
+
+/** A directed connection between two {@link WorkflowNode}s. */
+export interface WorkflowEdge {
+  id: string
+  source: string
+  target: string
+  sourceHandle?: string
+  targetHandle?: string
+}
+
+/** How a workflow gets launched. */
+export interface WorkflowTrigger {
+  type: 'manual' | 'scheduled' | 'github' | 'feishu' | 'context-menu' | 'visit-web'
+  /** Cron-ish or interval text for scheduled triggers. */
+  schedule?: string
+  enabled?: boolean
+  /**
+   * Glob/regex text a URL must match for a `'visit-web'` trigger to fire. The
+   * workflow is executed when the matched page commits navigation.
+   */
+  urlPattern?: string
+  /**
+   * Explicit context-menu item id for a `'context-menu'` trigger. When unset,
+   * the workflow's own id is used as the menu item id.
+   */
+  menuItemId?: string
+}
+
+/** Execution / persistence options that travel with a workflow. */
+export interface WorkflowSettings {
+  /** Persist run transcripts to the run log. */
+  saveLog: boolean
+  debugMode: boolean
+  /** Whether runs should post a notification when they settle. */
+  notification: boolean
+  /** Reuse the previous run's captured page state on the next run. */
+  reuseLastState: boolean
+  /** Target column name for table-backed workflows. */
+  defaultColumnName?: string
+}
+
+/** A persisted workflow. */
+export interface Workflow {
+  id: string
+  name: string
+  description?: string
+  /** Owning folder id, when workflows are grouped. */
+  folderId?: string
+  createdAt: number
+  updatedAt: number
+  /** React-flow-ish graph data. */
+  drawflow: {
+    nodes: WorkflowNode[]
+    edges: WorkflowEdge[]
+    position?: { x: number; y: number }
+    zoom?: number
+  }
+  trigger?: WorkflowTrigger
+  settings: WorkflowSettings
+  /** Backing data-store reference (e.g. a spreadsheet table id). */
+  table?: unknown
+}
+
+/** A named value a workflow reads and writes at runtime. */
+export interface WorkflowVariable {
+  id: string
+  name: string
+  value: unknown
+}
+
+/** Execution-time context handed to a running workflow. */
+export interface WorkflowRunContext {
+  workflowId: string
+  trigger: WorkflowTrigger
+  settings: WorkflowSettings
+  /** Runtime variable values, keyed by variable name. */
+  variables: Record<string, unknown>
+  startedAt: number
+  /** The active browser-page id, if one is captured. */
+  pageId?: string
+  /** Set to request early termination of the run. */
+  cancelled?: boolean
+}

--- a/src/lib/workflow/validation.ts
+++ b/src/lib/workflow/validation.ts
@@ -1,0 +1,109 @@
+/**
+ * Import-time structural validation for workflows.
+ *
+ * {@link validateWorkflow} is intentionally separate from persistence: it
+ * returns a list of human-readable problems (rather than throwing) so a UI can
+ * present every defect in a pasted/imported payload at once, and so storage can
+ * reject corrupt payloads before writing them.
+ *
+ * @module lib/workflow/validation
+ */
+
+import type { Workflow } from './types'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * Returns a list of validation error messages for `value`, or `[]` when the
+ * value is a well-formed workflow.
+ *
+ * Only structural invariants are checked here (shape, required fields, types);
+ * semantic checks such as "edge targets a node that exists" are left to callers
+ * that have the full graph.
+ */
+export function validateWorkflow(value: unknown): string[] {
+  const errors: string[] = []
+
+  if (!isRecord(value)) {
+    return ['workflow must be an object']
+  }
+
+  const id = value.id
+  if (typeof id !== 'string' || id.trim() === '') {
+    errors.push('workflow requires a non-empty id')
+  }
+  const name = value.name
+  if (typeof name !== 'string' || name.trim() === '') {
+    errors.push('workflow requires a non-empty name')
+  }
+
+  const drawflow = value.drawflow
+  if (!isRecord(drawflow)) {
+    errors.push('workflow requires a drawflow object')
+    return errors
+  }
+
+  const nodes = drawflow.nodes
+  if (!Array.isArray(nodes)) {
+    errors.push('drawflow.nodes must be an array')
+  } else {
+    nodes.forEach((node, i) => {
+      if (!isRecord(node)) {
+        errors.push(`nodes[${i}] must be an object`)
+        return
+      }
+      if (typeof node.id !== 'string' || String(node.id).trim() === '') {
+        errors.push(`nodes[${i}] requires a non-empty id`)
+      }
+      if (typeof node.label !== 'string') {
+        errors.push(`nodes[${i}] requires a string label`)
+      }
+      const pos = node.position
+      if (!isRecord(pos)) {
+        errors.push(`nodes[${i}] requires a position`)
+      } else if (typeof pos.x !== 'number' || typeof pos.y !== 'number') {
+        errors.push(`nodes[${i}].position requires numeric x and y`)
+      }
+    })
+  }
+
+  const edges = drawflow.edges
+  if (!Array.isArray(edges)) {
+    errors.push('drawflow.edges must be an array')
+  } else {
+    edges.forEach((edge, i) => {
+      if (!isRecord(edge)) {
+        errors.push(`edges[${i}] must be an object`)
+        return
+      }
+      if (typeof edge.id !== 'string' || String(edge.id).trim() === '') {
+        errors.push(`edges[${i}] requires a non-empty id`)
+      }
+      if (typeof edge.source !== 'string') {
+        errors.push(`edges[${i}] requires a string source`)
+      }
+      if (typeof edge.target !== 'string') {
+        errors.push(`edges[${i}] requires a string target`)
+      }
+    })
+  }
+
+  if (!isRecord(value.settings)) {
+    errors.push('workflow requires a settings object')
+  }
+  if (typeof value.createdAt !== 'number') {
+    errors.push('workflow requires a numeric createdAt')
+  }
+  if (typeof value.updatedAt !== 'number') {
+    errors.push('workflow requires a numeric updatedAt')
+  }
+
+  return errors
+}
+
+/** Convenience: does {@link validateWorkflow} report no problems? */
+export function isWorkflowValid(value: unknown): value is Workflow {
+  return validateWorkflow(value).length === 0
+}

--- a/src/offscreen/index.html
+++ b/src/offscreen/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Browser Copilot Clipboard</title>
+  </head>
+  <body>
+    <script type="module" src="./index.ts"></script>
+  </body>
+</html>

--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Offscreen document backing the `clipboard` workflow block.
+ *
+ * `navigator.clipboard.readText()` requires a focused document with the
+ * `clipboardRead` permission and a user gesture in some Chrome versions, but an
+ * offscreen document can serve the extension's own read/write needs without
+ * disturbing the page the user is looking at. This page simply listens for
+ * `clip-get` / `clip-set` messages and answers back with the text.
+ *
+ * @module offscreen/index
+ */
+
+void chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (!message || typeof message !== 'object') return undefined
+  if (message.type !== 'clip-get' && message.type !== 'clip-set') return undefined
+
+  void (async () => {
+    try {
+      if (message.type === 'clip-get') {
+        const text = await navigator.clipboard.readText()
+        sendResponse({ ok: true, text })
+      } else {
+        await navigator.clipboard.writeText(String(message.text ?? ''))
+        sendResponse({ ok: true })
+      }
+    } catch (error) {
+      sendResponse({ ok: false, error: error instanceof Error ? error.message : String(error) })
+    }
+  })()
+
+  // Keep the message channel open until the async handler responds.
+  return true
+})

--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -4,19 +4,26 @@ import { sendCommand } from '../lib/messages'
 import type { Skill } from '../lib/types'
 import ChatTab from './ChatTab'
 import DataTab from './DataTab'
+import HistoryTab from './HistoryTab'
 import { I18nProvider } from './i18n'
 import SettingsTab from './SettingsTab'
 import SkillsTab from './SkillsTab'
 import TasksTab from './TasksTab'
+import WorkflowsTab from './WorkflowsTab'
 
-type TabId = 'chat' | 'skills' | 'tasks' | 'data' | 'settings'
+type TabId = 'chat' | 'skills' | 'tasks' | 'workflows' | 'history' | 'data' | 'settings'
 
-const TAB_ORDER: TabId[] = ['chat', 'skills', 'tasks', 'data', 'settings']
+/** Always shown in the top bar. */
+const PINNED_TABS: TabId[] = ['chat', 'workflows', 'history', 'tasks']
+/** Collected under the fixed "More" dropdown. */
+const MORE_TABS: TabId[] = ['skills', 'data', 'settings']
 
 const TAB_LABEL: Record<TabId, keyof Messages> = {
   chat: 'tabChat',
   skills: 'tabSkills',
   tasks: 'tabTasks',
+  workflows: 'tabWorkflows',
+  history: 'tabHistory',
   data: 'tabData',
   settings: 'tabSettings',
 }
@@ -72,10 +79,30 @@ export default function App() {
     }
   }, [skills, activeSkillId])
 
+  // --- "More" dropdown menu ------------------------------------------------
+  const [moreOpen, setMoreOpen] = useState(false)
+
+  // Close the "More" menu when clicking outside.
+  useEffect(() => {
+    if (!moreOpen) return
+    const onDown = (): void => setMoreOpen(false)
+    document.addEventListener('mousedown', onDown)
+    return () => document.removeEventListener('mousedown', onDown)
+  }, [moreOpen])
+
+  // History tab dispatches `bc:open-conversation` when the user clicks
+  // "continue chat" on a past conversation. Switch to the Chat tab and let
+  // ChatTab's own listener do the resume.
+  useEffect(() => {
+    const handler = (): void => setActive('chat')
+    window.addEventListener('bc:open-conversation', handler)
+    return () => window.removeEventListener('bc:open-conversation', handler)
+  }, [])
+
   return (
     <I18nProvider value={i18n}>
       <nav className="tabs">
-        {TAB_ORDER.map((id) => (
+        {PINNED_TABS.map((id) => (
           <button
             key={id}
             className="tab"
@@ -86,6 +113,38 @@ export default function App() {
             {i18n.t[TAB_LABEL[id]] as string}
           </button>
         ))}
+        <div className="tab-more-wrap">
+          <button
+            className="tab tab-more"
+            data-active={MORE_TABS.includes(active)}
+            onClick={(e) => {
+              e.stopPropagation()
+              setMoreOpen((v) => !v)
+            }}
+            type="button"
+          >
+            {i18n.t.tabMore}
+            <span className="tab-more-caret">▾</span>
+          </button>
+          {moreOpen && (
+            <div className="tab-more-menu" onMouseDown={(e) => e.stopPropagation()}>
+              {MORE_TABS.map((id) => (
+                <button
+                  key={id}
+                  className="tab-more-item"
+                  data-active={active === id}
+                  onClick={() => {
+                    setActive(id)
+                    setMoreOpen(false)
+                  }}
+                  type="button"
+                >
+                  {i18n.t[TAB_LABEL[id]] as string}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
       </nav>
       {/*
         Every tab stays mounted: the chat holds a live port and streaming
@@ -113,6 +172,12 @@ export default function App() {
       </div>
       <div style={{ display: active === 'tasks' ? 'contents' : 'none' }}>
         <TasksTab />
+      </div>
+      <div style={{ display: active === 'workflows' ? 'contents' : 'none' }}>
+        <WorkflowsTab />
+      </div>
+      <div style={{ display: active === 'history' ? 'contents' : 'none' }}>
+        <HistoryTab />
       </div>
       <div style={{ display: active === 'data' ? 'contents' : 'none' }}>
         <DataTab />

--- a/src/sidepanel/ChatTab.tsx
+++ b/src/sidepanel/ChatTab.tsx
@@ -22,7 +22,8 @@ import {
   type TurnTokenUsage,
   sendCommand,
 } from '../lib/messages'
-import { DEFAULT_CONVERSATION_ID, newId } from '../lib/storage'
+import { DEFAULT_CONVERSATION_ID, newId, workflowFromHistory } from '../lib/storage'
+import type { Workflow } from '../lib/workflow/types'
 import type { AgentMode, ConversationMeta } from '../lib/types'
 import {
   applySlashPick,
@@ -238,6 +239,49 @@ export default function ChatTab({ skills, activeSkillId, onSelectSkill }: Props)
   const tRef = useRef(t)
   tRef.current = t
 
+  /**
+   * "Save this session as a workflow?" call-to-action, shown right after a turn
+   * that actually performed page operations in semi/full-auto. `conversationId`
+   * guards against saving another conversation's flow by mistake.
+   */
+  const [workflowPrompt, setWorkflowPrompt] = useState<{
+    conversationId: string
+    workflow: Workflow
+    steps: number
+  } | null>(null)
+  /** Last reuseable-step count we already asked about per conversation. */
+  const promptedRef = useRef<Record<string, number>>({})
+  const conversationsRef = useRef<ConversationMeta[]>(conversations)
+  conversationsRef.current = conversations
+
+  /**
+   * After a turn that performed page operations, offer to persist them as a
+   * reusable workflow. Only actions that actually ran (approved + ok) in this
+   * conversation count; if none map to a block we stay quiet. A per-conversation
+   * counter means we only ask again once new steps have accumulated.
+   */
+  const maybePromptSaveWorkflow = useCallback(async (convId: string) => {
+    let result: Awaited<ReturnType<typeof sendCommand>>
+    try {
+      result = await sendCommand({ type: 'history.list' })
+    } catch {
+      return
+    }
+    if (result.type !== 'history.list') return
+    const session = result.entries
+      .filter((e) => e.conversationId === convId && e.ok && e.approved)
+      .sort((a, b) => a.at - b.at)
+    const meta = conversationsRef.current.find((c) => c.id === convId)
+    const name = (meta?.title ?? '').trim() || `session-${convId.slice(0, 6)}`
+    const workflow = workflowFromHistory(session, name)
+    if (!workflow) return
+    const steps = workflow.drawflow.nodes.length
+    if (steps === 0) return
+    if ((promptedRef.current[convId] ?? 0) >= steps) return
+    promptedRef.current[convId] = steps
+    setWorkflowPrompt({ conversationId: convId, workflow, steps })
+  }, [])
+
   const append = useCallback((entry: Omit<Entry, 'id'>) => {
     setEntries((prev) => [...prev, { id: nextId(), ...entry }])
   }, [])
@@ -365,6 +409,7 @@ export default function ChatTab({ skills, activeSkillId, onSelectSkill }: Props)
             clearPhase()
             streamingRef.current = null
             setBusy(false)
+            void maybePromptSaveWorkflow(conversationId)
             if (message.usage) {
               setLastUsage(message.usage)
               setSessionUsage((prev) => ({
@@ -439,7 +484,7 @@ export default function ChatTab({ skills, activeSkillId, onSelectSkill }: Props)
       portRef.current?.disconnect()
       portRef.current = null
     }
-  }, [append, appendDelta, clearPhase, conversationId, showPhase])
+  }, [append, appendDelta, clearPhase, conversationId, maybePromptSaveWorkflow, showPhase])
 
   // Refresh the conversation list when it changes and on mount.
   const refreshConversations = useCallback(async () => {
@@ -497,10 +542,27 @@ export default function ChatTab({ skills, activeSkillId, onSelectSkill }: Props)
     setConversationId(id)
     setEntries([])
     setConfirms([])
+    setWorkflowPrompt(null)
     streamingRef.current = null
     resetUsage()
     // The port's resume effect fires on conversationId change and restores.
   }
+
+  // History tab's "continue chat" button dispatches this window event so it
+  // can resume a conversation without importing ChatTab. The app shell flips
+  // to the Chat tab in parallel; we just open the thread here.
+  useEffect(() => {
+    const handler = (event: Event): void => {
+      const id = (event as CustomEvent<{ id: string }>).detail?.id
+      if (id) openConversation(id)
+    }
+    window.addEventListener('bc:open-conversation', handler)
+    return () => window.removeEventListener('bc:open-conversation', handler)
+    // openConversation references `busy` and several setters; re-binding on
+    // every render is cheap and ensures we never hold a stale closure over
+    // `busy`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  })
 
   const startNewConversation = (): void => {
     if (busy) return
@@ -509,6 +571,7 @@ export default function ChatTab({ skills, activeSkillId, onSelectSkill }: Props)
     setConversationId(id)
     setEntries([])
     setConfirms([])
+    setWorkflowPrompt(null)
     streamingRef.current = null
     resetUsage()
     void refreshConversations()
@@ -536,6 +599,7 @@ export default function ChatTab({ skills, activeSkillId, onSelectSkill }: Props)
     if (id === conversationId) {
       setEntries([])
       setConfirms([])
+      setWorkflowPrompt(null)
       streamingRef.current = null
       setConversationId(DEFAULT_CONVERSATION_ID)
     }
@@ -625,11 +689,31 @@ export default function ChatTab({ skills, activeSkillId, onSelectSkill }: Props)
     streamingRef.current = null
     setBusy(true)
     setDraft('')
+    setWorkflowPrompt(null)
   }
 
   const answerConfirm = (requestId: string, approved: boolean): void => {
     post({ type: 'confirm', requestId, approved })
     setConfirms((prev) => prev.filter((item) => item.requestId !== requestId))
+  }
+
+  const savePromptWorkflow = async (): Promise<void> => {
+    const prompt = workflowPrompt
+    if (!prompt) return
+    setWorkflowPrompt(null)
+    try {
+      await sendCommand({ type: 'workflows.save', workflow: prompt.workflow })
+      append({
+        role: 'status',
+        text: tRef.current.chatSaveWorkflowSaved({ name: prompt.workflow.name }),
+      })
+    } catch (error) {
+      append({ role: 'error', text: (error as Error).message })
+    }
+  }
+
+  const dismissPromptWorkflow = (): void => {
+    setWorkflowPrompt(null)
   }
 
   // --- Slash menu ------------------------------------------------------------
@@ -883,6 +967,23 @@ export default function ChatTab({ skills, activeSkillId, onSelectSkill }: Props)
             </div>
           </div>
         ))}
+
+        {workflowPrompt && (
+          <div className="confirm-card" data-kind="workflow">
+            <strong>{t.chatSaveWorkflowPrompt({ steps: workflowPrompt.steps })}</strong>
+            <p className="hint" style={{ margin: '6px 0' }}>
+              {workflowPrompt.workflow.name}
+            </p>
+            <div className="actions">
+              <button className="primary" onClick={() => void savePromptWorkflow()} type="button">
+                {t.chatSaveWorkflowSave}
+              </button>
+              <button onClick={dismissPromptWorkflow} type="button">
+                {t.chatSaveWorkflowSkip}
+              </button>
+            </div>
+          </div>
+        )}
       </div>
 
       <div

--- a/src/sidepanel/DataTab.tsx
+++ b/src/sidepanel/DataTab.tsx
@@ -1,18 +1,17 @@
 /**
- * Data tab: manage saved profiles, password/identity entries, and action
- * history. Everything here lives in `chrome.storage.local`; the worker exposes
- * it via plain commands.
+ * Data tab: manage saved profiles and password/identity entries.
+ * Action history has moved to the History tab.
  *
  * @module sidepanel/DataTab
  */
 import { useCallback, useEffect, useState } from 'react'
 import { sendCommand } from '../lib/messages'
 import { newId } from '../lib/storage'
-import type { ConversationMeta, HistoryEntry, PasswordEntry, UserProfile } from '../lib/types'
+import type { PasswordEntry, UserProfile } from '../lib/types'
 import { entryFields } from '../lib/types'
 import { useT } from './i18n'
 
-type Section = 'profiles' | 'passwords' | 'history'
+type Section = 'profiles' | 'passwords'
 
 function emptyProfile(): UserProfile {
   return {
@@ -57,14 +56,6 @@ function serializeCustom(custom: Record<string, string>): string {
     .join('\n')
 }
 
-function formatWhen(ms: number): string {
-  const date = new Date(ms)
-  const now = new Date()
-  const sameDay = date.toDateString() === now.toDateString()
-  const time = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-  if (sameDay) return time
-  return `${date.toLocaleDateString()} ${time}`
-}
 
 export default function DataTab() {
   const t = useT()
@@ -73,8 +64,6 @@ export default function DataTab() {
 
   const [profiles, setProfiles] = useState<UserProfile[] | null>(null)
   const [passwords, setPasswords] = useState<PasswordEntry[] | null>(null)
-  const [history, setHistory] = useState<HistoryEntry[] | null>(null)
-  const [conversations, setConversations] = useState<ConversationMeta[]>([])
 
   const [profileDraft, setProfileDraft] = useState<UserProfile | null>(null)
   const [customText, setCustomText] = useState('')
@@ -94,21 +83,11 @@ export default function DataTab() {
     const result = await sendCommand({ type: 'passwords.list' })
     if (result.type === 'passwords.list') setPasswords(result.entries)
   }, [])
-  const loadHistory = useCallback(async () => {
-    const result = await sendCommand({ type: 'history.list' })
-    if (result.type === 'history.list') setHistory(result.entries)
-  }, [])
-  const loadConversations = useCallback(async () => {
-    const result = await sendCommand({ type: 'conversations.list' })
-    if (result.type === 'conversations.list') setConversations(result.conversations)
-  }, [])
 
   useEffect(() => {
     void loadProfiles().catch((error) => flash('error', (error as Error).message))
     void loadPasswords().catch((error) => flash('error', (error as Error).message))
-    void loadHistory().catch((error) => flash('error', (error as Error).message))
-    void loadConversations().catch(() => {})
-  }, [loadProfiles, loadPasswords, loadHistory, loadConversations])
+  }, [loadProfiles, loadPasswords])
 
   const startProfile = (profile?: UserProfile): void => {
     // Coerce every known field to a string defensively. A panel/worker version
@@ -186,15 +165,6 @@ export default function DataTab() {
     await loadPasswords()
   }
 
-  const removeHistory = async (id: string): Promise<void> => {
-    await sendCommand({ type: 'history.delete', id })
-    await loadHistory()
-  }
-  const clearAllHistory = async (): Promise<void> => {
-    await sendCommand({ type: 'history.clear' })
-    await loadHistory()
-  }
-
   return (
     <div className="pane">
       {banner && (
@@ -207,7 +177,7 @@ export default function DataTab() {
         <div className="card-title">{t.dataTitle}</div>
         <p className="hint">{t.dataIntro}</p>
         <div className="tabs" style={{ margin: '4px 0 0' }}>
-          {(['profiles', 'passwords', 'history'] as Section[]).map((id) => (
+          {(['profiles', 'passwords'] as Section[]).map((id) => (
             <button
               key={id}
               className="tab"
@@ -215,11 +185,7 @@ export default function DataTab() {
               onClick={() => setSection(id)}
               type="button"
             >
-              {id === 'profiles'
-                ? t.dataProfiles
-                : id === 'passwords'
-                  ? t.dataSecrets
-                  : t.dataHistory}
+              {id === 'profiles' ? t.dataProfiles : t.dataSecrets}
             </button>
           ))}
         </div>
@@ -254,16 +220,6 @@ export default function DataTab() {
           onDraftChange={setPasswordDraft}
           onSave={savePassword}
           onCancel={() => setPasswordDraft(null)}
-        />
-      )}
-
-      {section === 'history' && (
-        <HistorySection
-          t={t}
-          history={history}
-          conversations={conversations}
-          onDelete={removeHistory}
-          onClear={clearAllHistory}
         />
       )}
     </div>
@@ -577,115 +533,3 @@ function PasswordsSection({
   )
 }
 
-// --- History ----------------------------------------------------------------
-
-interface HistoryProps {
-  t: ReturnType<typeof useT>
-  history: HistoryEntry[] | null
-  conversations: ConversationMeta[]
-  onDelete: (id: string) => void
-  onClear: () => void
-}
-
-interface HistoryGroup {
-  key: string
-  title: string
-  entries: HistoryEntry[]
-}
-
-function groupHistory(
-  history: HistoryEntry[],
-  conversations: ConversationMeta[],
-): HistoryGroup[] {
-  const titleOf = (id: string): string => {
-    if (id.startsWith('task:')) return id.slice(5) || 'Scheduled task'
-    if (id.startsWith('feishu:')) return 'Feishu'
-    const meta = conversations.find((c) => c.id === id)
-    return meta?.title || id
-  }
-  const order: string[] = []
-  const map = new Map<string, HistoryEntry[]>()
-  for (const entry of history) {
-    const key = entry.conversationId || 'unknown'
-    if (!map.has(key)) {
-      map.set(key, [])
-      order.push(key)
-    }
-    map.get(key)!.push(entry)
-  }
-  // history is already newest-first; groups follow their newest entry.
-  return order.map((key) => ({ key, title: titleOf(key), entries: map.get(key)! }))
-}
-
-function HistorySection({ t, history, conversations, onDelete, onClear }: HistoryProps) {
-  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
-  const groups = history ? groupHistory(history, conversations) : []
-
-  return (
-    <>
-      <div className="card">
-        <div className="card-title">{t.dataHistory}</div>
-        <p className="hint">{t.dataHistoryIntro}</p>
-        {history && history.length > 0 && (
-          <div className="actions">
-            <button className="danger" onClick={() => void onClear()} type="button">
-              {t.dataClearHistory}
-            </button>
-          </div>
-        )}
-      </div>
-      {history && history.length === 0 && <div className="empty">{t.dataHistoryEmpty}</div>}
-      {groups.map((group) => {
-        const okCount = group.entries.filter((e) => e.ok && e.approved).length
-        const failCount = group.entries.filter((e) => !e.ok).length
-        const isOpen = expanded[group.key] ?? false
-        return (
-          <div className="card history-group" key={group.key}>
-            <button
-              className="history-group-head"
-              onClick={() => setExpanded((prev) => ({ ...prev, [group.key]: !isOpen }))}
-              type="button"
-            >
-              <span className="history-caret">{isOpen ? '▾' : '▸'}</span>
-              <span className="history-group-title">{group.title}</span>
-              <span className="history-count">{group.entries.length}</span>
-              {failCount > 0 ? (
-                <span className="history-stat history-stat-err">{failCount} ✕</span>
-              ) : (
-                <span className="history-stat history-stat-ok">{okCount} ✓</span>
-              )}
-            </button>
-            {isOpen && (
-              <ul className="history-steps">
-                {group.entries.map((entry) => (
-                  <li className={`history-step history-step-${entry.ok ? 'ok' : 'err'}`} key={entry.id}>
-                    <div className="history-step-head">
-                      <span className="history-step-time">{formatWhen(entry.at)}</span>
-                      {entry.host && <span className="history-host">{entry.host}</span>}
-                      {!entry.approved && <span className="history-declined">{t.dataDeclined}</span>}
-                      <button
-                        className="danger history-delete"
-                        onClick={() => void onDelete(entry.id)}
-                        type="button"
-                      >
-                        ×
-                      </button>
-                    </div>
-                    <div className="history-summary">{entry.summary || entry.action}</div>
-                    {entry.detail && entry.detail.length > 0 && (
-                      <ul className="history-detail">
-                        {entry.detail.map((line, i) => (
-                          <li key={i}>{line}</li>
-                        ))}
-                      </ul>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        )
-      })}
-    </>
-  )
-}

--- a/src/sidepanel/HistoryTab.tsx
+++ b/src/sidepanel/HistoryTab.tsx
@@ -1,0 +1,833 @@
+/**
+ * History tab: a top-level panel tab aggregating every kind of record the
+ * extension persists — conversations (对话历史), workflow runs (工作流运行历史),
+ * task runs (任务运行历史), and the raw action-history entries (数据操作记录).
+ *
+ * Each sub-section supports expandable detail, single delete (× button), and
+ * batch delete (checkbox + "delete selected"), keeping the audit trail under
+ * the user's control. A live activity board at the top shows currently running
+ * workflow/task runs (the board previously duplicated on the Workflows and
+ * Tasks tabs) so all run-related history — live and persisted — lives in one
+ * place.
+ *
+ * Workflow and task runs both live in `tasks.runs` (`TaskRunLog[]`) and are
+ * distinguished by `source`: interactions initiated from the UI or chat
+ * (`manual`/`chat`) are workflow runs; schedule/Feishu-initiated ones
+ * (`schedule`/`feishu`) are task runs. A single top-level load of the run log
+ * is shared between the two sections so the worker is only queried once.
+ *
+ * @module sidepanel/HistoryTab
+ */
+import { useCallback, useEffect, useState } from "react";
+import { sendCommand } from "../lib/messages";
+import { workflowFromHistory } from "../lib/storage";
+import { saveWorkflow } from "../lib/workflow/storage";
+import type { ConversationMeta, HistoryEntry } from "../lib/types";
+import type { TaskRunLog } from "../lib/scheduler-types";
+import { useT } from "./i18n";
+import RunningBoard from "./RunningBoard";
+
+type Section = "conversations" | "workflowRuns" | "taskRuns" | "operations";
+
+type Banner = { kind: "ok" | "error"; text: string } | null;
+
+interface SectionProps {
+  t: ReturnType<typeof useT>;
+  flash: (kind: "ok" | "error", text: string) => void;
+}
+
+/** Same-day → time only, otherwise date + time. */
+function formatWhen(ms: number): string {
+  const date = new Date(ms);
+  const now = new Date();
+  const sameDay = date.toDateString() === now.toDateString();
+  const time = date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  if (sameDay) return time;
+  return `${date.toLocaleDateString()} ${time}`;
+}
+
+/**
+ * Ask the Chat tab to open a conversation and continue chatting in it.
+ *
+ * The side panel keeps every tab mounted so Chat can hold a live port; we
+ * don't import it directly (that would drag its streaming state into the
+ * history bundle), we dispatch a custom window event that ChatTab + App
+ * listen for. App flips the active tab, ChatTab resumes the thread.
+ */
+function continueConversation(id: string): void {
+  window.dispatchEvent(new CustomEvent("bc:open-conversation", { detail: { id } }));
+}
+
+// --- Operations: grouping ---------------------------------------------------
+
+interface HistoryGroup {
+  key: string;
+  title: string;
+  entries: HistoryEntry[];
+}
+
+/** Groups action-history entries by conversationId, newest-first. */
+function groupHistory(history: HistoryEntry[], conversations: ConversationMeta[]): HistoryGroup[] {
+  const titleOf = (id: string): string => {
+    if (id.startsWith("task:")) return id.slice(5) || "Scheduled task";
+    if (id.startsWith("feishu:")) return "Feishu";
+    const meta = conversations.find((c) => c.id === id);
+    return meta?.title || id;
+  };
+  const order: string[] = [];
+  const map = new Map<string, HistoryEntry[]>();
+  for (const entry of history) {
+    const key = entry.conversationId || "unknown";
+    if (!map.has(key)) {
+      map.set(key, []);
+      order.push(key);
+    }
+    map.get(key)!.push(entry);
+  }
+  // history is already newest-first; groups follow their newest entry.
+  return order.map((key) => ({ key, title: titleOf(key), entries: map.get(key)! }));
+}
+
+export default function HistoryTab() {
+  const t = useT();
+  const [section, setSection] = useState<Section>("conversations");
+  const [banner, setBanner] = useState<Banner>(null);
+  // One shared load of the full run log, split by `source` in the two run
+  // sections so the service worker is only queried once.
+  const [runs, setRuns] = useState<TaskRunLog[] | null>(null);
+
+  const flash = useCallback((kind: "ok" | "error", text: string): void => {
+    setBanner({ kind, text });
+  }, []);
+
+  const reloadRuns = useCallback(async (): Promise<void> => {
+    try {
+      const result = await sendCommand({ type: "tasks.runs" });
+      if (result.type === "tasks.runs") setRuns(result.runs);
+    } catch (error) {
+      flash("error", (error as Error).message);
+    }
+  }, [flash]);
+
+  useEffect(() => {
+    void reloadRuns();
+  }, [reloadRuns]);
+
+  const sections: Array<{ id: Section; label: string }> = [
+    { id: "conversations", label: t.histConversations },
+    { id: "workflowRuns", label: t.histWorkflowRuns },
+    { id: "taskRuns", label: t.histTaskRuns },
+    { id: "operations", label: t.histOperations },
+  ];
+
+  return (
+    <div className="pane history-tab">
+      {banner && (
+        <div className="banner" data-kind={banner.kind} onClick={() => setBanner(null)}>
+          {banner.text}
+        </div>
+      )}
+
+      <RunningBoard onSettled={() => void reloadRuns()} />
+
+      <div className="tabs history-sections" role="tablist">
+        {sections.map(({ id, label }) => (
+          <button
+            key={id}
+            className="tab"
+            data-active={section === id}
+            onClick={() => setSection(id)}
+            type="button"
+            role="tab"
+            aria-selected={section === id}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {section === "conversations" && <ConversationsSection t={t} flash={flash} />}
+      {section === "workflowRuns" && (
+        <RunsSection
+          t={t}
+          flash={flash}
+          runs={runs}
+          reload={reloadRuns}
+          filter={(run) => run.source === "manual" || run.source === "chat"}
+        />
+      )}
+      {section === "taskRuns" && (
+        <RunsSection
+          t={t}
+          flash={flash}
+          runs={runs}
+          reload={reloadRuns}
+          filter={(run) => run.source === "schedule" || run.source === "feishu"}
+        />
+      )}
+      {section === "operations" && <OperationsSection t={t} flash={flash} />}
+    </div>
+  );
+}
+
+// --- Shared helpers ---------------------------------------------------------
+
+/** Toggle a string id in a Set, returning a new Set (immutable). */
+function toggleId(set: Set<string>, id: string): Set<string> {
+  const next = new Set(set);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  return next;
+}
+
+/** Select-all / deselect-all toggle based on current all-selected state. */
+function selectAllToggle<T extends { id: string }>(
+  items: T[] | null,
+  selected: Set<string>,
+): Set<string> {
+  const allSelected = items !== null && items.length > 0 && items.every((i) => selected.has(i.id));
+  if (allSelected) return new Set();
+  return new Set((items ?? []).map((i) => i.id));
+}
+
+type BadgeKind = "ok" | "err" | "cancel" | "skip";
+
+function badgeKind(run: TaskRunLog): BadgeKind {
+  if (run.skipped) return "skip";
+  if (run.ok) return "ok";
+  return run.outcome === "cancelled" ? "cancel" : "err";
+}
+
+function badgeLabel(t: ReturnType<typeof useT>, run: TaskRunLog): string {
+  if (run.skipped) return t.histOutcomeSkipped;
+  if (run.ok) return t.histOutcomeOk;
+  return run.outcome === "cancelled" ? t.histOutcomeCancelled : t.histOutcomeFailed;
+}
+
+/** Human-readable trigger source, reused from the Tasks tab vocabulary. */
+function sourceLabel(t: ReturnType<typeof useT>, source: TaskRunLog["source"] | undefined): string {
+  switch (source) {
+    case "chat":
+      return t.taskSourceChat;
+    case "schedule":
+      return t.taskSourceSchedule;
+    case "manual":
+      return t.taskSourceManual;
+    case "feishu":
+      return t.taskSourceFeishu;
+    default:
+      return "";
+  }
+}
+
+interface BatchBarProps {
+  count: number;
+  total: number;
+  onSelectAll: () => void;
+  onDelete: () => void;
+  t: ReturnType<typeof useT>;
+  /** Optional extra control on the right (e.g. "clear all" for operations). */
+  extra?: React.ReactNode;
+}
+
+/** Sticky batch-delete toolbar shared by every list section. */
+function BatchBar({ count, total, onSelectAll, onDelete, t, extra }: BatchBarProps) {
+  const allSelected = total > 0 && count === total;
+  const noneSelected = total === 0;
+  return (
+    <div className="card record-batchbar">
+      <label className="record-batchbar-check">
+        <input
+          type="checkbox"
+          checked={allSelected}
+          ref={(el) => {
+            // Indeterminate when some, but not all, visible items are selected.
+            if (el) el.indeterminate = count > 0 && !allSelected;
+          }}
+          disabled={noneSelected}
+          onChange={onSelectAll}
+          aria-label={t.histSelectAll}
+        />
+        <span>{t.histSelectAll}</span>
+      </label>
+      <div className="record-batchbar-count">
+        {count > 0 ? `${count} / ${total}` : total > 0 ? `共 ${total} 条` : ""}
+      </div>
+      <div className="record-batchbar-actions">
+        {extra}
+        <button className="danger" onClick={onDelete} type="button" disabled={count === 0}>
+          {t.histBatchDelete}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// --- Conversations ----------------------------------------------------------
+
+interface ConvState {
+  /** True while the transcript is being fetched for the first time. */
+  loading: boolean;
+  /** Cached transcript; persists across collapse/re-expand. */
+  messages: { role: "user" | "assistant" | "tool"; text: string }[];
+  /** Whether the detail panel is currently visible. */
+  open: boolean;
+}
+
+function ConversationsSection({ t, flash }: SectionProps) {
+  const [items, setItems] = useState<ConversationMeta[] | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  // One entry per conversation the user has ever expanded. `messages` is
+  // cached so collapse + re-open is instant and we never query the worker
+  // twice for the same transcript.
+  const [state, setState] = useState<Record<string, ConvState>>({});
+
+  const load = useCallback(async (): Promise<void> => {
+    try {
+      const result = await sendCommand({ type: "conversations.list" });
+      if (result.type === "conversations.list") setItems(result.conversations);
+    } catch (error) {
+      flash("error", (error as Error).message);
+    }
+  }, [flash]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const toggle = useCallback(
+    async (id: string): Promise<void> => {
+      const current = state[id];
+      if (current) {
+        // Already loaded at least once — toggle open/closed, keep messages.
+        setState((prev) => ({
+          ...prev,
+          [id]: { ...current, open: !current.open },
+        }));
+        return;
+      }
+      // First expansion: mark loading + open, fetch once.
+      setState((prev) => ({
+        ...prev,
+        [id]: { loading: true, messages: [], open: true },
+      }));
+      try {
+        const result = await sendCommand({ type: "conversations.get", id });
+        const messages = result.type === "conversations.get" ? result.messages : [];
+        setState((prev) => ({
+          ...prev,
+          [id]: { loading: false, messages, open: prev[id]?.open ?? true },
+        }));
+      } catch (error) {
+        flash("error", (error as Error).message);
+        setState((prev) => ({ ...prev, [id]: { loading: false, messages: [], open: false } }));
+      }
+    },
+    [state, flash],
+  );
+
+  const removeOne = useCallback(
+    async (id: string): Promise<void> => {
+      try {
+        await sendCommand({ type: "conversations.delete", id });
+        setSelected((prev) => {
+          if (!prev.has(id)) return prev;
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+        await load();
+      } catch (error) {
+        flash("error", (error as Error).message);
+      }
+    },
+    [flash, load],
+  );
+
+  const removeSelected = useCallback(async (): Promise<void> => {
+    if (selected.size === 0) return;
+    if (!confirm(t.histDeleteConfirm({ count: selected.size }))) return;
+    const count = selected.size;
+    try {
+      for (const id of selected) {
+        await sendCommand({ type: "conversations.delete", id });
+      }
+      setSelected(new Set());
+      await load();
+      flash("ok", `${count}`);
+    } catch (error) {
+      flash("error", (error as Error).message);
+      await load();
+    }
+  }, [selected, t, flash, load]);
+
+  return (
+    <div className="record-section">
+      {items !== null && items.length > 0 && (
+        <BatchBar
+          count={selected.size}
+          total={items.length}
+          onSelectAll={() => setSelected((prev) => selectAllToggle(items, prev))}
+          onDelete={() => void removeSelected()}
+          t={t}
+        />
+      )}
+      {items !== null && items.length === 0 && <div className="empty">{t.histEmpty}</div>}
+      {items?.map((conv) => {
+        const detail = state[conv.id];
+        const isOpen = detail?.open ?? false;
+        return (
+          <div className="record-card conv-record" key={conv.id}>
+            <div
+              className="record-head"
+              onClick={() => void toggle(conv.id)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  void toggle(conv.id);
+                }
+              }}
+            >
+              <input
+                type="checkbox"
+                className="record-check"
+                checked={selected.has(conv.id)}
+                onClick={(e) => e.stopPropagation()}
+                onChange={() => setSelected((prev) => toggleId(prev, conv.id))}
+                aria-label={conv.title}
+              />
+              <span className={`record-caret${isOpen ? " open" : ""}`} aria-hidden="true" />
+              <span className="record-title">{conv.title}</span>
+              <span className="record-meta">
+                <span className="record-time">{formatWhen(conv.createdAt)}</span>
+              </span>
+              <button
+                className="icon-btn danger record-delete"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void removeOne(conv.id);
+                }}
+                title={t.delete}
+                aria-label={t.delete}
+                type="button"
+              >
+                ×
+              </button>
+            </div>
+            {conv.preview && <div className="record-summary">{conv.preview}</div>}
+            {detail && isOpen && (
+              <div className="record-detail conv-msgs">
+                {detail.loading ? (
+                  <div className="hint">{t.loading}</div>
+                ) : detail.messages.length === 0 ? (
+                  <div className="hint">{t.convHistoryEmpty}</div>
+                ) : (
+                  <>
+                    {detail.messages.map((m, i) => (
+                      <div key={i} className={`record-msg record-msg-${m.role}`}>
+                        {m.text}
+                      </div>
+                    ))}
+                    <div className="conv-actions">
+                      <button
+                        className="primary conv-continue"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          continueConversation(conv.id);
+                        }}
+                        type="button"
+                      >
+                        {t.convContinue}
+                      </button>
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// --- Runs: shared by workflow-runs and task-runs sections -------------------
+
+interface RunsSectionProps extends SectionProps {
+  runs: TaskRunLog[] | null;
+  reload: () => Promise<void>;
+  filter: (run: TaskRunLog) => boolean;
+}
+
+function RunsSection({ t, flash, runs, reload, filter }: RunsSectionProps) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+  const items = (runs ?? [])
+    .filter(filter)
+    .slice()
+    .sort((a, b) => (b.startedAt ?? b.at) - (a.startedAt ?? a.at));
+
+  const removeOne = useCallback(
+    async (id: string): Promise<void> => {
+      try {
+        await sendCommand({ type: "tasks.runs.delete", id });
+        setSelected((prev) => {
+          if (!prev.has(id)) return prev;
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+        await reload();
+      } catch (error) {
+        flash("error", (error as Error).message);
+      }
+    },
+    [flash, reload],
+  );
+
+  const removeSelected = useCallback(async (): Promise<void> => {
+    if (selected.size === 0) return;
+    if (!confirm(t.histDeleteConfirm({ count: selected.size }))) return;
+    const count = selected.size;
+    try {
+      for (const id of selected) {
+        await sendCommand({ type: "tasks.runs.delete", id });
+      }
+      setSelected(new Set());
+      await reload();
+      flash("ok", `${count}`);
+    } catch (error) {
+      flash("error", (error as Error).message);
+      await reload();
+    }
+  }, [selected, t, flash, reload]);
+
+  const clearAll = useCallback(async (): Promise<void> => {
+    if (items.length === 0) return;
+    if (!confirm(t.histDeleteConfirm({ count: items.length }))) return;
+    try {
+      await sendCommand({ type: "tasks.runs.clear" });
+      setSelected(new Set());
+      await reload();
+    } catch (error) {
+      flash("error", (error as Error).message);
+    }
+  }, [items.length, t, flash, reload]);
+
+  return (
+    <div className="record-section">
+      {items.length > 0 && (
+        <BatchBar
+          count={selected.size}
+          total={items.length}
+          onSelectAll={() => setSelected((prev) => selectAllToggle(items, prev))}
+          onDelete={() => void removeSelected()}
+          t={t}
+          extra={
+            <button className="danger ghost" onClick={() => void clearAll()} type="button">
+              {t.taskRunsClear}
+            </button>
+          }
+        />
+      )}
+      {items.length === 0 && <div className="empty">{t.histEmptyRuns}</div>}
+      {items.map((run) => {
+        const isOpen = open[run.id] ?? false;
+        const label = run.label || run.taskId || run.id;
+        const kind = badgeKind(run);
+        const src = sourceLabel(t, run.source);
+        return (
+          <div className="record-card run-record" key={run.id}>
+            <div
+              className="record-head"
+              onClick={() => setOpen((prev) => ({ ...prev, [run.id]: !isOpen }))}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setOpen((prev) => ({ ...prev, [run.id]: !isOpen }));
+                }
+              }}
+            >
+              <input
+                type="checkbox"
+                className="record-check"
+                checked={selected.has(run.id)}
+                onClick={(e) => e.stopPropagation()}
+                onChange={() => setSelected((prev) => toggleId(prev, run.id))}
+                aria-label={label}
+              />
+              <span className={`record-caret${isOpen ? " open" : ""}`} aria-hidden="true" />
+              <span className="record-title">{label}</span>
+              <span className="record-meta">
+                {src && <span className="record-source">{src}</span>}
+                {run.startedAt && <span className="record-time">{formatWhen(run.startedAt)}</span>}
+                <span className={`status-badge ${kind}`}>{badgeLabel(t, run)}</span>
+              </span>
+              <button
+                className="icon-btn danger record-delete"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void removeOne(run.id);
+                }}
+                title={t.delete}
+                aria-label={t.delete}
+                type="button"
+              >
+                ×
+              </button>
+            </div>
+            {run.summary && <div className="record-summary">{run.summary}</div>}
+            {/* Show failure detail even on a collapsed card so a broken run is
+                visible without having to expand every failed row. */}
+            {!isOpen && run.error && run.error !== run.summary && (
+              <div className="record-error-inline">{run.error}</div>
+            )}
+            {isOpen && (
+              <div className="record-detail">
+                {run.error && <div className="record-error">{run.error}</div>}
+                {run.steps && run.steps.length > 0 ? (
+                  <ul className="record-steps">
+                    {run.steps.map((step, i) => (
+                      <li key={i} className="record-step" data-kind={step.kind}>
+                        <span className="record-step-time">{formatWhen(step.at)}</span>
+                        <span className="record-step-tag">{step.kind}</span>
+                        <span className="record-step-text">{step.text}</span>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <div className="hint">{t.histNoSteps}</div>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// --- Operations (action history) --------------------------------------------
+
+function OperationsSection({ t, flash }: SectionProps) {
+  const [entries, setEntries] = useState<HistoryEntry[] | null>(null);
+  const [conversations, setConversations] = useState<ConversationMeta[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const load = useCallback(async (): Promise<void> => {
+    try {
+      const [histResult, convResult] = await Promise.all([
+        sendCommand({ type: "history.list" }),
+        sendCommand({ type: "conversations.list" }),
+      ]);
+      if (histResult.type === "history.list") setEntries(histResult.entries);
+      if (convResult.type === "conversations.list") setConversations(convResult.conversations);
+    } catch (error) {
+      flash("error", (error as Error).message);
+    }
+  }, [flash]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const removeOne = useCallback(
+    async (id: string): Promise<void> => {
+      try {
+        await sendCommand({ type: "history.delete", id });
+        setSelected((prev) => {
+          if (!prev.has(id)) return prev;
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+        await load();
+      } catch (error) {
+        flash("error", (error as Error).message);
+      }
+    },
+    [flash, load],
+  );
+
+  const removeSelected = useCallback(async (): Promise<void> => {
+    if (selected.size === 0) return;
+    if (!confirm(t.histDeleteConfirm({ count: selected.size }))) return;
+    const count = selected.size;
+    try {
+      for (const id of selected) {
+        await sendCommand({ type: "history.delete", id });
+      }
+      setSelected(new Set());
+      await load();
+      flash("ok", `${count}`);
+    } catch (error) {
+      flash("error", (error as Error).message);
+      await load();
+    }
+  }, [selected, t, flash, load]);
+
+  const clearAll = useCallback(async (): Promise<void> => {
+    const total = entries?.length ?? 0;
+    if (total === 0) return;
+    if (!confirm(t.histDeleteConfirm({ count: total }))) return;
+    try {
+      await sendCommand({ type: "history.clear" });
+      setSelected(new Set());
+      await load();
+      flash("ok", `${total}`);
+    } catch (error) {
+      flash("error", (error as Error).message);
+    }
+  }, [entries, t, flash, load]);
+
+  /** Rebuilds a linear workflow from a group's action steps (oldest first). */
+  const rebuild = useCallback(
+    async (groupTitle: string, groupEntries: HistoryEntry[]): Promise<void> => {
+      try {
+        const workflow = workflowFromHistory([...groupEntries].reverse(), `从历史: ${groupTitle}`);
+        if (!workflow) {
+          flash("error", t.dataHistoryToWorkflowEmpty);
+          return;
+        }
+        await saveWorkflow(workflow);
+        flash("ok", t.dataHistoryToWorkflowDone);
+      } catch (error) {
+        flash("error", (error as Error).message);
+      }
+    },
+    [flash, t],
+  );
+
+  const groups = entries ? groupHistory(entries, conversations) : [];
+  // Select-all only affects entries whose group is currently expanded so the
+  // checkbox never silently selects rows the user cannot see.
+  const visibleEntries = groups.flatMap((g) => (expanded[g.key] ? g.entries : []));
+
+  const toggleGroup = (key: string): void => {
+    setExpanded((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  return (
+    <div className="record-section">
+      {entries !== null && entries.length > 0 && (
+        <BatchBar
+          count={selected.size}
+          total={visibleEntries.length}
+          onSelectAll={() => setSelected((prev) => selectAllToggle(visibleEntries, prev))}
+          onDelete={() => void removeSelected()}
+          t={t}
+          extra={
+            <button className="danger ghost" onClick={() => void clearAll()} type="button">
+              {t.dataClearHistory}
+            </button>
+          }
+        />
+      )}
+      {entries !== null && entries.length === 0 && <div className="empty">{t.histEmpty}</div>}
+      {groups.map((group) => {
+        const okCount = group.entries.filter((e) => e.ok && e.approved).length;
+        const failCount = group.entries.filter((e) => !e.ok).length;
+        const isOpen = expanded[group.key] ?? false;
+        return (
+          <div className="record-card history-group" key={group.key}>
+            <div
+              className="record-head history-group-head"
+              onClick={() => toggleGroup(group.key)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  toggleGroup(group.key);
+                }
+              }}
+            >
+              <span className="record-caret-spacer" aria-hidden="true" />
+              <span className={`record-caret${isOpen ? " open" : ""}`} aria-hidden="true" />
+              <span className="record-title history-group-title">{group.title}</span>
+              <span className="record-meta">
+                <span className="history-count">{group.entries.length}</span>
+                {failCount > 0 ? (
+                  <span className="history-stat history-stat-err">{failCount} ✕</span>
+                ) : (
+                  <span className="history-stat history-stat-ok">{okCount} ✓</span>
+                )}
+              </span>
+              <button
+                className="icon-btn history-rebuild"
+                title={t.dataHistoryToWorkflow}
+                aria-label={t.dataHistoryToWorkflow}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void rebuild(group.title, group.entries);
+                }}
+                type="button"
+              >
+                ⟳
+              </button>
+            </div>
+            {isOpen && (
+              <ul className="history-steps">
+                {group.entries.map((entry) => (
+                  <li
+                    className={`history-step history-step-${entry.ok ? "ok" : "err"}`}
+                    key={entry.id}
+                  >
+                    <div className="history-step-head">
+                      <input
+                        type="checkbox"
+                        className="record-check"
+                        checked={selected.has(entry.id)}
+                        onClick={(e) => e.stopPropagation()}
+                        onChange={() => setSelected((prev) => toggleId(prev, entry.id))}
+                        aria-label={entry.summary || entry.action}
+                      />
+                      <span className="history-step-time">{formatWhen(entry.at)}</span>
+                      <span className="history-meta">
+                        {entry.host && <span className="history-host">{entry.host}</span>}
+                        {!entry.approved && (
+                          <span className="history-declined">{t.dataDeclined}</span>
+                        )}
+                      </span>
+                      <button
+                        className="icon-btn danger history-delete"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void removeOne(entry.id);
+                        }}
+                        title={t.delete}
+                        aria-label={t.delete}
+                        type="button"
+                      >
+                        ×
+                      </button>
+                    </div>
+                    <div className="history-summary">{entry.summary || entry.action}</div>
+                    {entry.detail && entry.detail.length > 0 && (
+                      <ul className="history-detail">
+                        {entry.detail.map((line, i) => (
+                          <li key={i}>{line}</li>
+                        ))}
+                      </ul>
+                    )}
+                    {entry.args && Object.keys(entry.args).length > 0 && (
+                      <div className="record-args">
+                        <span className="record-json-label">{t.histArgs}</span>
+                        <pre className="record-json">{JSON.stringify(entry.args, null, 2)}</pre>
+                      </div>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/sidepanel/RunningBoard.tsx
+++ b/src/sidepanel/RunningBoard.tsx
@@ -1,0 +1,310 @@
+/**
+ * Shared "activity" board: live list of currently running workflow/task runs
+ * plus a strip of the most recently finished ones.
+ *
+ * Previously this board was duplicated at the top of the Workflows tab and the
+ * Tasks tab, each with its own polling loop. It now lives here so the History
+ * tab is the single place a user watches or cancels a run. The component
+ * manages its own polling, cancellation state, and finished-step expansion;
+ * the parent only supplies an `onSettled` callback if it wants to reload
+ * persistent data after a run leaves the running set.
+ *
+ * The worker returns the same view for both `tasks.running` and
+ * `workflows.running`; we always use `tasks.*` commands because cancel /
+ * delete / clear are all namespaced that way.
+ *
+ * @module sidepanel/RunningBoard
+ */
+import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react'
+import { sendCommand, type FinishedTaskView, type RunningTaskView } from '../lib/messages'
+import { useT } from './i18n'
+
+interface RunningBoardProps {
+  /**
+   * Called whenever the board observes a run leaving the running set or a new
+   * entry appearing in the finished set — the signal for the parent to reload
+   * any persisted run log it displays below.
+   */
+  onSettled?: () => void
+  /** Disables all interactive controls while the parent is busy. */
+  busy?: boolean
+}
+
+export default function RunningBoard({ onSettled, busy }: RunningBoardProps): ReactElement {
+  const t = useT()
+  const [running, setRunning] = useState<RunningTaskView[]>([])
+  const [finished, setFinished] = useState<FinishedTaskView[]>([])
+  const [cancellingIds, setCancellingIds] = useState<Set<string>>(new Set())
+  const [localBusy, setLocalBusy] = useState(false)
+
+  const anyBusy = Boolean(busy) || localBusy
+
+  const prevRunningIds = useRef<Set<string>>(new Set())
+  const prevFinishedIds = useRef<Set<string>>(new Set())
+  // Keep the latest onSettled without resetting the polling interval each render.
+  const onSettledRef = useRef(onSettled)
+  useEffect(() => {
+    onSettledRef.current = onSettled
+  }, [onSettled])
+
+  const refresh = useCallback(async (): Promise<void> => {
+    try {
+      const result = await sendCommand({ type: 'tasks.running' })
+      if (result.type !== 'tasks.running') return
+      setRunning(result.runs)
+      setFinished(result.finished)
+
+      const runningIds = new Set(result.runs.map((r) => r.runId))
+      const finishedIds = new Set(result.finished.map((r) => r.runId))
+
+      // Once a cancelled run leaves the running list, drop its "Cancelling…"
+      // state so a future run never inherits it.
+      setCancellingIds((prev) => {
+        if (prev.size === 0) return prev
+        let changed = false
+        const next = new Set<string>()
+        for (const id of prev) {
+          if (runningIds.has(id)) next.add(id)
+          else changed = true
+        }
+        return changed ? next : prev
+      })
+
+      let settled = false
+      for (const id of prevRunningIds.current) {
+        if (!runningIds.has(id)) {
+          settled = true
+          break
+        }
+      }
+      if (!settled) {
+        for (const id of finishedIds) {
+          if (!prevFinishedIds.current.has(id)) {
+            settled = true
+            break
+          }
+        }
+      }
+      if (settled) onSettledRef.current?.()
+      prevRunningIds.current = runningIds
+      prevFinishedIds.current = finishedIds
+    } catch {
+      /* non-fatal; keep polling */
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+    const timer = setInterval(() => void refresh(), 1500)
+    return () => clearInterval(timer)
+  }, [refresh])
+
+  const cancelRunning = useCallback(async (runId: string): Promise<void> => {
+    setCancellingIds((prev) => {
+      const next = new Set(prev)
+      next.add(runId)
+      return next
+    })
+    setLocalBusy(true)
+    try {
+      await sendCommand({ type: 'tasks.cancel', runId })
+      await refresh()
+    } finally {
+      setLocalBusy(false)
+    }
+  }, [refresh])
+
+  const deleteFinished = useCallback(async (runId: string): Promise<void> => {
+    setLocalBusy(true)
+    try {
+      await sendCommand({ type: 'tasks.finished.delete', runId })
+      await refresh()
+    } finally {
+      setLocalBusy(false)
+    }
+  }, [refresh])
+
+  const clearFinished = useCallback(async (): Promise<void> => {
+    if (!confirm(t.taskClearFinishedConfirm)) return
+    setLocalBusy(true)
+    try {
+      await sendCommand({ type: 'tasks.finished.clear' })
+      await refresh()
+    } finally {
+      setLocalBusy(false)
+    }
+  }, [t, refresh])
+
+  const sourceLabel = (source: RunningTaskView['source']): string => {
+    switch (source) {
+      case 'feishu':
+        return t.taskSourceFeishu
+      case 'chat':
+        return t.taskSourceChat
+      case 'manual':
+        return t.taskSourceManual
+      case 'schedule':
+      default:
+        return t.taskSourceSchedule
+    }
+  }
+
+  const outcomeLabel = (outcome: FinishedTaskView['outcome']): string => {
+    switch (outcome) {
+      case 'ok':
+        return t.taskOutcomeOk
+      case 'cancelled':
+        return t.taskOutcomeCancelled
+      case 'skipped':
+        return t.taskOutcomeSkipped
+      case 'failed':
+      default:
+        return t.taskOutcomeFailed
+    }
+  }
+
+  return (
+    <div className={`card running-board${running.length > 0 ? ' running-board-active' : ''}`}>
+      <div className="card-head">
+        <h3>
+          {running.length > 0 && <span className="running-dot" />}
+          {t.tasksActivity}
+          {running.length > 0 && <span className="running-count">{running.length}</span>}
+        </h3>
+      </div>
+
+      {running.length === 0 ? (
+        <p className="hint running-empty">{t.tasksRunningEmpty}</p>
+      ) : (
+        <ul className="running-list">
+          {running.map((run) => {
+            const cancelling = cancellingIds.has(run.runId)
+            return (
+              <li className="running-item" key={run.runId}>
+                <div className="running-item-head">
+                  <strong className="running-label">{run.label || t.taskUntitled}</strong>
+                  <button
+                    className={`running-cancel${cancelling ? ' running-cancel-busy' : ''}`}
+                    disabled={anyBusy || cancelling}
+                    onClick={() => void cancelRunning(run.runId)}
+                    type="button"
+                  >
+                    {cancelling ? t.taskCancelling : t.taskTerminate}
+                  </button>
+                </div>
+                <div className="running-meta">
+                  <span className="run-tag">{sourceLabel(run.source)}</span>
+                  <span>
+                    {t.taskStartedAt}: {new Date(run.startedAt).toLocaleTimeString(navigator.language)}
+                  </span>
+                </div>
+                {run.steps.length > 0 && (
+                  <ul className="running-steps">
+                    {run.steps.slice(-8).map((step, index) => (
+                      <li className={`running-step running-step-${step.kind}`} key={index}>
+                        {step.text}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      )}
+
+      {finished.length > 0 && (
+        <>
+          <div className="running-divider" />
+          <div className="running-section-head">
+            <h4 className="running-section-title">{t.tasksRecentlyFinished}</h4>
+            <button
+              className="link running-clear"
+              disabled={anyBusy}
+              onClick={() => void clearFinished()}
+              type="button"
+            >
+              {t.taskClearFinished}
+            </button>
+          </div>
+          <FinishedList
+            runs={finished.slice(0, 8)}
+            sourceLabel={sourceLabel}
+            outcomeLabel={outcomeLabel}
+            onDelete={(id) => void deleteFinished(id)}
+            disabled={anyBusy}
+            t={t}
+          />
+        </>
+      )}
+    </div>
+  )
+}
+
+// --- Finished runs -----------------------------------------------------------
+
+interface FinishedListProps {
+  runs: FinishedTaskView[]
+  sourceLabel: (source: FinishedTaskView['source']) => string
+  outcomeLabel: (outcome: FinishedTaskView['outcome']) => string
+  onDelete: (runId: string) => void
+  disabled?: boolean
+  t: ReturnType<typeof useT>
+}
+
+function FinishedList({
+  runs,
+  sourceLabel,
+  outcomeLabel,
+  onDelete,
+  disabled,
+  t,
+}: FinishedListProps): ReactElement {
+  const [openId, setOpenId] = useState<string | null>(null)
+  return (
+    <ul className="finished-list">
+      {runs.map((run) => {
+        const isOpen = openId === run.runId
+        return (
+          <li className={`finished-item finished-${run.outcome}`} key={run.runId}>
+            <button
+              className="finished-row"
+              disabled={disabled || run.steps.length === 0}
+              onClick={() => setOpenId(isOpen ? null : run.runId)}
+              type="button"
+            >
+              <span className="finished-caret">
+                {run.steps.length > 0 ? (isOpen ? '▾' : '▸') : ''}
+              </span>
+              <span className={`finished-dot finished-dot-${run.outcome}`} />
+              <span className="finished-name">{run.label || t.taskUntitled}</span>
+              <span className="run-tag">{sourceLabel(run.source)}</span>
+              <span className={`finished-badge finished-badge-${run.outcome}`}>
+                {outcomeLabel(run.outcome)}
+              </span>
+            </button>
+            <button
+              aria-label={t.delete}
+              className="danger finished-delete"
+              disabled={disabled}
+              onClick={() => onDelete(run.runId)}
+              title={t.delete}
+              type="button"
+            >
+              ×
+            </button>
+            {isOpen && run.steps.length > 0 && (
+              <ul className="running-steps finished-steps">
+                {run.steps.map((step, index) => (
+                  <li className={`running-step running-step-${step.kind}`} key={index}>
+                    {step.text}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/src/sidepanel/TasksTab.tsx
+++ b/src/sidepanel/TasksTab.tsx
@@ -5,13 +5,17 @@
  * All persistence goes through `sendCommand`; the worker owns alarms and the
  * Feishu connection, so saving here both stores and re-arms everything.
  *
+ * Live run progress and the run-history log now live in the History tab's
+ * activity board (see `RunningBoard.tsx`); this tab only manages task
+ * definitions.
+ *
  * @module sidepanel/TasksTab
  */
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { sendCommand, type FinishedTaskView, type RunningTaskView } from '../lib/messages'
+import { useCallback, useEffect, useState } from 'react'
+import { sendCommand } from '../lib/messages'
 import { createDraft } from '../lib/task-store'
 import { describeSchedule } from '../lib/schedule'
-import type { FeishuConfig, ScheduledTask, TaskRunLog } from '../lib/scheduler-types'
+import type { FeishuConfig, ScheduledTask } from '../lib/scheduler-types'
 import { useT } from './i18n'
 
 /** Editable form state. */
@@ -44,17 +48,12 @@ function emptyTask(): Draft {
 export default function TasksTab() {
   const t = useT()
   const [tasks, setTasks] = useState<ScheduledTask[]>([])
-  const [runs, setRuns] = useState<TaskRunLog[]>([])
-  const [running, setRunning] = useState<RunningTaskView[]>([])
-  const [finished, setFinished] = useState<FinishedTaskView[]>([])
   const [feishu, setFeishu] = useState<FeishuConfig | null>(null)
   const [draft, setDraft] = useState<Draft | null>(null)
   const [banner, setBanner] = useState<{ kind: 'ok' | 'error'; text: string } | null>(null)
   const [busy, setBusy] = useState(false)
   /** Id of the task just saved, so its card can briefly highlight. */
   const [justSavedId, setJustSavedId] = useState<string | null>(null)
-  /** Runs whose terminate button was clicked; used to show "Cancelling…". */
-  const [cancellingIds, setCancellingIds] = useState<Set<string>>(new Set())
 
   // Clear the highlight a short time after it appears, without re-running load.
   useEffect(() => {
@@ -65,13 +64,11 @@ export default function TasksTab() {
 
   const load = useCallback(async () => {
     try {
-      const [taskResult, runsResult, feishuResult] = await Promise.all([
+      const [taskResult, feishuResult] = await Promise.all([
         sendCommand({ type: 'tasks.list' }),
-        sendCommand({ type: 'tasks.runs' }),
         sendCommand({ type: 'feishu.get' }),
       ])
       if (taskResult.type === 'tasks.list') setTasks(taskResult.tasks)
-      if (runsResult.type === 'tasks.runs') setRuns(runsResult.runs)
       if (feishuResult.type === 'feishu.get') setFeishu(feishuResult.config)
     } catch (error) {
       setBanner({ kind: 'error', text: error instanceof Error ? error.message : String(error) })
@@ -81,129 +78,6 @@ export default function TasksTab() {
   useEffect(() => {
     void load()
   }, [load])
-
-  // Poll the running-tasks board while the tab is mounted so progress steps and
-  // start/finish appear live. The persistent task list and run history are
-  // written by the worker but would otherwise stay stale until the tab is
-  // reopened, so we also reload them whenever we observe *activity*: a new run
-  // appears, a run leaves the running set, or a new entry shows up in the
-  // recently-finished board. Tracking finished ids (rather than running ids)
-  // catches runs that start and finish entirely between two 1.5s polls.
-  const prevRunningIds = useRef<Set<string>>(new Set())
-  const prevFinishedIds = useRef<Set<string>>(new Set())
-  useEffect(() => {
-    let active = true
-    const refresh = async (): Promise<void> => {
-      try {
-        const result = await sendCommand({ type: 'tasks.running' })
-        if (!active || result.type !== 'tasks.running') return
-        setRunning(result.runs)
-        setFinished(result.finished)
-
-        const runningIds = new Set(result.runs.map((r) => r.runId))
-        const finishedIds = new Set(result.finished.map((r) => r.runId))
-
-        // Once a cancelled run leaves the running list, drop its "Cancelling…"
-        // state so a future run never inherits it.
-        setCancellingIds((prev) => {
-          if (prev.size === 0) return prev
-          let changed = false
-          const next = new Set<string>()
-          for (const id of prev) {
-            if (runningIds.has(id)) next.add(id)
-            else changed = true
-          }
-          return changed ? next : prev
-        })
-
-        let shouldReload = false
-        // A run we previously saw running is no longer running → it settled.
-        for (const id of prevRunningIds.current) {
-          if (!runningIds.has(id)) {
-            shouldReload = true
-            break
-          }
-        }
-        // A brand-new entry appeared in the recently-finished board.
-        if (!shouldReload) {
-          for (const id of finishedIds) {
-            if (!prevFinishedIds.current.has(id)) {
-              shouldReload = true
-              break
-            }
-          }
-        }
-        if (shouldReload) void load()
-        prevRunningIds.current = runningIds
-        prevFinishedIds.current = finishedIds
-      } catch {
-        /* non-fatal; keep polling */
-      }
-    }
-    void refresh()
-    const timer = setInterval(() => void refresh(), 1500)
-    return () => {
-      active = false
-      clearInterval(timer)
-    }
-  }, [load])
-
-  const cancelRunning = async (runId: string): Promise<void> => {
-    setCancellingIds((prev) => {
-      const next = new Set(prev)
-      next.add(runId)
-      return next
-    })
-    setBusy(true)
-    try {
-      await sendCommand({ type: 'tasks.cancel', runId })
-      // Refresh immediately; the aborted run moves to the completed list shortly.
-      const result = await sendCommand({ type: 'tasks.running' })
-      if (result.type === 'tasks.running') {
-        setRunning(result.runs)
-        setFinished(result.finished)
-      }
-      await load()
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  const deleteFinished = async (runId: string): Promise<void> => {
-    if (!confirm(t.taskDeleteFinishedConfirm)) return
-    setBusy(true)
-    try {
-      await sendCommand({ type: 'tasks.finished.delete', runId })
-      const result = await sendCommand({ type: 'tasks.running' })
-      if (result.type === 'tasks.running') {
-        setRunning(result.runs)
-        setFinished(result.finished)
-      }
-      await load()
-    } catch (error) {
-      setBanner({ kind: 'error', text: error instanceof Error ? error.message : String(error) })
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  const clearFinished = async (): Promise<void> => {
-    if (!confirm(t.taskClearFinishedConfirm)) return
-    setBusy(true)
-    try {
-      await sendCommand({ type: 'tasks.finished.clear' })
-      const result = await sendCommand({ type: 'tasks.running' })
-      if (result.type === 'tasks.running') {
-        setRunning(result.runs)
-        setFinished(result.finished)
-      }
-      await load()
-    } catch (error) {
-      setBanner({ kind: 'error', text: error instanceof Error ? error.message : String(error) })
-    } finally {
-      setBusy(false)
-    }
-  }
 
   const persistTask = async (task: Draft): Promise<void> => {
     setBusy(true)
@@ -302,16 +176,6 @@ export default function TasksTab() {
           {banner.text}
         </div>
       )}
-
-      <RunningBoard
-        running={running}
-        finished={finished}
-        onCancel={(id) => void cancelRunning(id)}
-        onDeleteFinished={(id) => void deleteFinished(id)}
-        onClearFinished={() => void clearFinished()}
-        cancellingIds={cancellingIds}
-        busy={busy}
-      />
 
       <div className="section-head">
         <h3>{t.tasksMine}</h3>
@@ -431,29 +295,6 @@ export default function TasksTab() {
           />
         </details>
       )}
-
-      <details
-        className="collapsible"
-        onToggle={(event) => {
-          // Refresh the run log the moment the user expands it, so data is
-          // current even if no polled transition was observed.
-          if ((event.currentTarget as HTMLDetailsElement).open) void load()
-        }}
-      >
-        <summary>
-          <span className="collapsible-title">{t.tasksRunHistory}</span>
-          {runs.length > 0 && <span className="collapsible-count">{runs.length}</span>}
-        </summary>
-        <RunLog
-          runs={runs.slice(0, 20)}
-          onClear={() => void sendCommand({ type: 'tasks.runs.clear' }).then(load)}
-          onDelete={(id) =>
-            void sendCommand({ type: 'tasks.runs.delete', id }).then(() => {
-              setRuns((prev) => prev.filter((r) => r.id !== id))
-            })
-          }
-        />
-      </details>
     </div>
   )
 }
@@ -797,278 +638,5 @@ function FeishuSection({
         </>
       )}
     </div>
-  )
-}
-
-// --- Run log -----------------------------------------------------------------
-
-function RunLog({
-  runs,
-  onClear,
-  onDelete,
-}: {
-  runs: TaskRunLog[]
-  onClear: () => void
-  onDelete: (id: string) => void
-}) {
-  const t = useT()
-  const [openId, setOpenId] = useState<string | null>(null)
-  const sourceLabel = (run: TaskRunLog): string => {
-    const src = run.source ?? (run.trigger === 'feishu' ? 'feishu' : run.trigger === 'manual' ? 'manual' : 'schedule')
-    return src === 'feishu'
-      ? t.taskTriggerFeishu
-      : src === 'manual'
-        ? t.taskTriggerManual
-        : src === 'chat'
-          ? t.taskTriggerChat
-          : t.taskTriggerSchedule
-  }
-  const outcomeLabel = (run: TaskRunLog): string => {
-    if (run.skipped) return t.taskOutcomeSkipped
-    if (run.outcome === 'cancelled') return t.taskOutcomeCancelled
-    if (!run.ok) return t.taskOutcomeFailed
-    return t.taskOutcomeOk
-  }
-  return (
-    <div className="run-log-wrap">
-      <div className="run-log-bar">
-        <button className="link" onClick={onClear} type="button">
-          {t.taskRunsClear}
-        </button>
-      </div>
-      {runs.length === 0 ? (
-        <p className="hint">{t.taskRunsEmpty}</p>
-      ) : (
-        <ul className="run-log">
-          {runs.map((run) => {
-            const isOpen = openId === run.id
-            const hasSteps = !!run.steps && run.steps.length > 0
-            return (
-              <li
-                className={`run-line run-${run.skipped ? 'skipped' : run.ok ? 'ok' : 'err'}`}
-                key={run.id}
-              >
-                <button
-                  className="run-line-head"
-                  disabled={!hasSteps}
-                  onClick={() => setOpenId(isOpen ? null : run.id)}
-                  type="button"
-                >
-                  <span className="run-caret">{hasSteps ? (isOpen ? '▾' : '▸') : ''}</span>
-                  <span className="run-time">
-                    {new Date(run.finishedAt ?? run.at).toLocaleString(navigator.language)}
-                  </span>
-                  <span className="run-tag">{sourceLabel(run)}</span>
-                  <span className="run-name">{run.label || run.summary?.split('\n')[0] || ''}</span>
-                  <span className={`run-badge run-badge-${run.skipped ? 'skipped' : run.ok ? 'ok' : 'err'}`}>
-                    {outcomeLabel(run)}
-                  </span>
-                  <button
-                    aria-label={t.delete}
-                    className="danger run-delete"
-                    onClick={(event) => {
-                      event.stopPropagation()
-                      onDelete(run.id)
-                    }}
-                    title={t.delete}
-                    type="button"
-                  >
-                    ×
-                  </button>
-                </button>
-                {(run.summary || run.error) && (
-                  <div className="run-summary">{run.summary || run.error}</div>
-                )}
-                {isOpen && hasSteps && (
-                  <ul className="running-steps run-steps">
-                    {run.steps!.map((step, index) => (
-                      <li className={`running-step running-step-${step.kind}`} key={index}>
-                        {step.text}
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </li>
-            )
-          })}
-        </ul>
-      )}
-    </div>
-  )
-}
-
-// --- Running board -----------------------------------------------------------
-
-function RunningBoard({
-  running,
-  finished,
-  onCancel,
-  onDeleteFinished,
-  onClearFinished,
-  cancellingIds,
-  busy,
-}: {
-  running: RunningTaskView[]
-  finished: FinishedTaskView[]
-  onCancel: (runId: string) => void
-  onDeleteFinished: (runId: string) => void
-  onClearFinished: () => void
-  cancellingIds: Set<string>
-  busy: boolean
-}) {
-  const t = useT()
-  const sourceLabel = (source: RunningTaskView['source']): string =>
-    source === 'feishu'
-      ? t.taskSourceFeishu
-      : source === 'chat'
-        ? t.taskSourceChat
-        : source === 'manual'
-          ? t.taskSourceManual
-          : t.taskSourceSchedule
-  const outcomeLabel = (outcome: FinishedTaskView['outcome']): string =>
-    outcome === 'ok'
-      ? t.taskOutcomeOk
-      : outcome === 'cancelled'
-        ? t.taskOutcomeCancelled
-        : outcome === 'skipped'
-          ? t.taskOutcomeSkipped
-          : t.taskOutcomeFailed
-
-  return (
-    <div className={`card running-board${running.length > 0 ? ' running-board-active' : ''}`}>
-      <div className="card-head">
-        <h3>
-          {running.length > 0 && <span className="running-dot" />}
-          {t.tasksActivity}
-          {running.length > 0 && <span className="running-count">{running.length}</span>}
-        </h3>
-      </div>
-
-      {running.length === 0 ? (
-        <p className="hint running-empty">{t.tasksRunningEmpty}</p>
-      ) : (
-        <ul className="running-list">
-          {running.map((run) => {
-            const cancelling = cancellingIds.has(run.runId)
-            return (
-            <li className="running-item" key={run.runId}>
-              <div className="running-item-head">
-                <strong className="running-label">{run.label || t.taskUntitled}</strong>
-                <button
-                  className={`running-cancel${cancelling ? ' running-cancel-busy' : ''}`}
-                  disabled={busy || cancelling}
-                  onClick={() => onCancel(run.runId)}
-                  type="button"
-                >
-                  {cancelling ? t.taskCancelling : t.taskTerminate}
-                </button>
-              </div>
-              <div className="running-meta">
-                <span className="run-tag">{sourceLabel(run.source)}</span>
-                <span>
-                  {t.taskStartedAt}: {new Date(run.startedAt).toLocaleTimeString(navigator.language)}
-                </span>
-              </div>
-              {run.steps.length > 0 && (
-                <ul className="running-steps">
-                  {run.steps.slice(-8).map((step, index) => (
-                    <li className={`running-step running-step-${step.kind}`} key={index}>
-                      {step.text}
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </li>
-            )
-          })}
-        </ul>
-      )}
-
-      {finished.length > 0 && (
-        <>
-          <div className="running-divider" />
-          <div className="running-section-head">
-            <h4 className="running-section-title">{t.tasksRecentlyFinished}</h4>
-            <button
-              className="link running-clear"
-              disabled={busy}
-              onClick={onClearFinished}
-              type="button"
-            >
-              {t.taskClearFinished}
-            </button>
-          </div>
-          <FinishedList
-            runs={finished.slice(0, 8)}
-            sourceLabel={sourceLabel}
-            outcomeLabel={outcomeLabel}
-            onDelete={onDeleteFinished}
-            t={t}
-          />
-        </>
-      )}
-    </div>
-  )
-}
-
-/** A recently-finished run whose steps can be expanded inline. */
-function FinishedList({
-  runs,
-  sourceLabel,
-  outcomeLabel,
-  onDelete,
-  t,
-}: {
-  runs: FinishedTaskView[]
-  sourceLabel: (source: FinishedTaskView['source']) => string
-  outcomeLabel: (outcome: FinishedTaskView['outcome']) => string
-  onDelete: (runId: string) => void
-  t: ReturnType<typeof useT>
-}) {
-  const [openId, setOpenId] = useState<string | null>(null)
-  return (
-    <ul className="finished-list">
-      {runs.map((run) => {
-        const isOpen = openId === run.runId
-        return (
-          <li className={`finished-item finished-${run.outcome}`} key={run.runId}>
-            <button
-              className="finished-row"
-              disabled={run.steps.length === 0}
-              onClick={() => setOpenId(isOpen ? null : run.runId)}
-              type="button"
-            >
-              <span className="finished-caret">
-                {run.steps.length > 0 ? (isOpen ? '▾' : '▸') : ''}
-              </span>
-              <span className={`finished-dot finished-dot-${run.outcome}`} />
-              <span className="finished-name">{run.label || t.taskUntitled}</span>
-              <span className="run-tag">{sourceLabel(run.source)}</span>
-              <span className={`finished-badge finished-badge-${run.outcome}`}>
-                {outcomeLabel(run.outcome)}
-              </span>
-            </button>
-            <button
-              aria-label={t.delete}
-              className="danger finished-delete"
-              onClick={() => onDelete(run.runId)}
-              title={t.delete}
-              type="button"
-            >
-              ×
-            </button>
-            {isOpen && run.steps.length > 0 && (
-              <ul className="running-steps finished-steps">
-                {run.steps.map((step, index) => (
-                  <li className={`running-step running-step-${step.kind}`} key={index}>
-                    {step.text}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </li>
-        )
-      })}
-    </ul>
   )
 }

--- a/src/sidepanel/WorkflowsTab.tsx
+++ b/src/sidepanel/WorkflowsTab.tsx
@@ -1,0 +1,337 @@
+/**
+ * Workflows tab: list/run/edit/delete workflows.
+ *
+ * Workflows are node-graph automations persisted in the worker. The visual
+ * editor lives in its own page (`src/workflow-editor/index.html`) opened in a
+ * new tab; this panel is the management surface — create, run, delete, and see
+ * each workflow's last-run status. Live run progress and the full run history
+ * now live in the History tab's activity board (see `RunningBoard.tsx`).
+ *
+ * @module sidepanel/WorkflowsTab
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { sendCommand } from '../lib/messages'
+import type { TaskRunLog } from '../lib/scheduler-types'
+import type { Workflow, WorkflowTrigger } from '../lib/workflow/types'
+import { newId } from '../lib/storage'
+import { useT } from './i18n'
+
+export default function WorkflowsTab() {
+  const t = useT()
+  const [workflows, setWorkflows] = useState<Workflow[]>([])
+  const [runs, setRuns] = useState<TaskRunLog[]>([])
+  const [banner, setBanner] = useState<{ kind: 'ok' | 'error'; text: string } | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const load = useCallback(async () => {
+    try {
+      const [workflowResult, runsResult] = await Promise.all([
+        sendCommand({ type: 'workflows.list' }),
+        sendCommand({ type: 'tasks.runs' }),
+      ])
+      if (workflowResult.type === 'workflows.list') setWorkflows(workflowResult.workflows)
+      if (runsResult.type === 'tasks.runs') setRuns(runsResult.runs)
+    } catch (error) {
+      setBanner({ kind: 'error', text: error instanceof Error ? error.message : String(error) })
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  // Auto-refresh when workflows are added/edited/deleted externally (e.g.
+  // saved from ChatTab's "save as workflow" prompt or imported in bulk).
+  useEffect(() => {
+    const handler = (
+      changes: { [key: string]: chrome.storage.StorageChange },
+      area: string,
+    ): void => {
+      if (area === 'local' && changes['workflows']) void load()
+    }
+    chrome.storage.onChanged.addListener(handler)
+    return () => chrome.storage.onChanged.removeListener(handler)
+  }, [load])
+
+  // Lightweight refresh so a workflow run launched elsewhere updates the
+  // last-run status chip without the user having to re-open the tab. Live
+  // progress / cancellation still lives in the History tab's activity board;
+  // here we only poll persisted state.
+  const lastLoadRef = useRef(0)
+  useEffect(() => {
+    const timer = setInterval(() => {
+      // Avoid stacking requests when the worker is slow.
+      if (Date.now() - lastLoadRef.current > 4000) {
+        lastLoadRef.current = Date.now()
+        void load()
+      }
+    }, 5000)
+    return () => clearInterval(timer)
+  }, [load])
+
+  const runNow = async (id: string): Promise<void> => {
+    setBusy(true)
+    try {
+      const result = await sendCommand({ type: 'workflows.run', id })
+      if (result.type === 'workflows.run') {
+        setBanner({
+          kind: result.outcome.ok ? 'ok' : 'error',
+          text: result.outcome.summary || result.outcome.error || t.taskStatusFailed,
+        })
+      }
+      await load()
+    } catch (error) {
+      setBanner({ kind: 'error', text: error instanceof Error ? error.message : String(error) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const removeWorkflow = async (id: string): Promise<void> => {
+    if (!confirm(t.workflowsDeleteConfirm)) return
+    setBusy(true)
+    try {
+      await sendCommand({ type: 'workflows.delete', id })
+      await load()
+    } catch (error) {
+      setBanner({ kind: 'error', text: error instanceof Error ? error.message : String(error) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const openEditor = (id?: string): void => {
+    void chrome.tabs.create({
+      url: chrome.runtime.getURL('src/workflow-editor/index.html' + (id ? `?edit=${encodeURIComponent(id)}` : '')),
+    })
+  }
+
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const downloadJSON = (filename: string, data: unknown): void => {
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = filename
+    anchor.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const exportWorkflow = (wf: Workflow): void => {
+    downloadJSON(`${(wf.name || 'workflow').replace(/[\\/:*?"<>|]/g, '-')}.json`, wf)
+  }
+
+  const exportAll = (): void => {
+    downloadJSON('workflows.json', workflows)
+  }
+
+  const importFiles = async (files: FileList | null): Promise<void> => {
+    if (!files || files.length === 0) return
+    setBusy(true)
+    let imported = 0
+    let invalid = false
+    try {
+      for (const file of Array.from(files)) {
+        try {
+          const text = await file.text()
+          const parsed: unknown = JSON.parse(text)
+          const batch: unknown[] = Array.isArray(parsed) ? parsed : [parsed]
+          for (const raw of batch) {
+            const wf = coerceImportedWorkflow(raw)
+            if (!wf) {
+              invalid = true
+              continue
+            }
+            await sendCommand({ type: 'workflows.save', workflow: wf })
+            imported += 1
+          }
+        } catch {
+          invalid = true
+        }
+      }
+    } catch (error) {
+      setBanner({ kind: 'error', text: error instanceof Error ? error.message : String(error) })
+      setBusy(false)
+      return
+    }
+    setBusy(false)
+    if (invalid && imported === 0) {
+      setBanner({ kind: 'error', text: t.workflowsImportInvalid })
+    } else if (imported > 0) {
+      const message = invalid
+        ? `${t.workflowsImported({ count: imported })} ${t.workflowsImportInvalid}`
+        : t.workflowsImported({ count: imported })
+      setBanner({ kind: 'ok', text: message })
+    }
+    await load()
+  }
+
+  const triggerLabel = (triggerType: WorkflowTrigger['type'] | undefined): string => {
+    switch (triggerType) {
+      case 'manual':
+        return t.workflowsTriggerManual
+      case 'scheduled':
+        return t.workflowsTriggerScheduled
+      case 'context-menu':
+        return t.workflowsTriggerContextMenu
+      case 'visit-web':
+        return t.workflowsTriggerVisitWeb
+      case 'github':
+        return t.workflowsTriggerGithub
+      case 'feishu':
+        return t.workflowsTriggerFeishu
+      default:
+        return t.workflowsTriggerNone
+    }
+  }
+
+  /** Most recent persisted run for a workflow, or null when it never ran. */
+  const lastRunFor = (wf: Workflow): { time: number; ok: boolean; skipped: boolean } | null => {
+    let best: TaskRunLog | null = null
+    for (const run of runs) {
+      if (run.label !== wf.name) continue
+      const at = run.finishedAt ?? run.at
+      const bestAt = best ? (best.finishedAt ?? best.at) : -1
+      if (at > bestAt) best = run
+    }
+    if (!best) return null
+    return { time: best.finishedAt ?? best.at, ok: best.ok, skipped: best.skipped }
+  }
+
+  const lastRunLabel = (wf: Workflow): string => {
+    const last = lastRunFor(wf)
+    if (!last) return t.workflowsRunStatusNever
+    if (last.skipped) return t.taskOutcomeSkipped
+    return last.ok ? t.taskOutcomeOk : t.taskOutcomeFailed
+  }
+
+  return (
+    <div className="pane workflows-tab">
+      <h2>{t.tabWorkflows}</h2>
+
+      {banner && (
+        <div className={`banner banner-${banner.kind}`} data-kind={banner.kind} role="status">
+          {banner.text}
+        </div>
+      )}
+
+      <div className="section-head">
+        <h3>{t.tabWorkflows}</h3>
+        <div className="section-actions">
+          {workflows.length > 0 && (
+            <button className="section-action" disabled={busy} onClick={exportAll} type="button">
+              {t.workflowsExport}
+            </button>
+          )}
+          <button
+            className="section-action"
+            disabled={busy}
+            onClick={() => fileInputRef.current?.click()}
+            type="button"
+          >
+            {t.workflowsImport}
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".json,application/json"
+            multiple
+            style={{ display: 'none' }}
+            onChange={(event) => void importFiles(event.target.files)}
+          />
+          <button
+            className="primary section-action"
+            disabled={busy}
+            onClick={() => openEditor()}
+            type="button"
+          >
+            + {t.workflowsNew}
+          </button>
+        </div>
+      </div>
+
+      {workflows.length === 0 ? (
+        <div className="empty-state">
+          <p>{t.workflowsEmpty}</p>
+        </div>
+      ) : (
+        <ul className="task-list">
+          {workflows.map((wf) => {
+            const last = lastRunFor(wf)
+            return (
+              <li className="task-item" key={wf.id}>
+                <div className="task-item-head">
+                  <strong className="task-item-name">{wf.name}</strong>
+                  <span className={`task-status task-status-${!last ? 'none' : last.skipped ? 'skipped' : last.ok ? 'ok' : 'failed'}`}>
+                    {lastRunLabel(wf)}
+                  </span>
+                </div>
+                <div className="task-meta">
+                  <span className="task-chip">{triggerLabel(wf.trigger?.type)}</span>
+                  {wf.description && <span className="task-lastrun">{wf.description}</span>}
+                </div>
+                {last && (
+                  <div className="task-lastrun">
+                    {t.workflowsLastRun}: {new Date(last.time).toLocaleString(navigator.language)}
+                  </div>
+                )}
+                <div className="actions task-actions">
+                  <button
+                    className="task-action-run"
+                    disabled={busy}
+                    onClick={() => void runNow(wf.id)}
+                    type="button"
+                  >
+                    {t.workflowsRunNow}
+                  </button>
+                  <button disabled={busy} onClick={() => openEditor(wf.id)} type="button">
+                    {t.workflowsEdit}
+                  </button>
+                  <button disabled={busy} onClick={() => exportWorkflow(wf)} type="button">
+                    {t.workflowsExport}
+                  </button>
+                  <button
+                    className="danger"
+                    disabled={busy}
+                    onClick={() => void removeWorkflow(wf.id)}
+                    type="button"
+                  >
+                    {t.delete}
+                  </button>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Validates an arbitrary imported value into a workflow record, assigning a
+ * fresh id and timestamps so it never collides with an existing workflow.
+ * Returns `null` when the record lacks the name + drawflow graph every workflow
+ * needs.
+ */
+function coerceImportedWorkflow(raw: unknown): Workflow | null {
+  if (!raw || typeof raw !== 'object') return null
+  const w = raw as Partial<Workflow>
+  if (
+    typeof w.name !== 'string' ||
+    !w.drawflow ||
+    typeof w.drawflow !== 'object' ||
+    !Array.isArray(w.drawflow.nodes)
+  ) {
+    return null
+  }
+  const now = Date.now()
+  return {
+    ...(w as Workflow),
+    id: newId(),
+    name: w.name.trim() || 'Imported workflow',
+    createdAt: now,
+    updatedAt: now,
+  }
+}

--- a/src/sidepanel/styles.css
+++ b/src/sidepanel/styles.css
@@ -130,6 +130,7 @@ body {
   padding: 8px 8px 0;
   border-bottom: 1px solid var(--border);
   background: var(--panel);
+  position: relative;
 }
 
 .tab {
@@ -142,12 +143,68 @@ body {
   cursor: pointer;
   font: inherit;
   font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .tab[data-active='true'] {
   background: var(--bg);
   color: var(--text);
   box-shadow: inset 0 -2px 0 var(--accent);
+}
+
+/* "More" tab dropdown for overflow */
+.tab-more-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.tab-more {
+  flex: none;
+  padding: 8px 12px;
+}
+
+.tab-more-caret {
+  margin-left: 4px;
+  font-size: 0.8em;
+}
+
+.tab-more-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  min-width: 120px;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: var(--menu-shadow);
+  padding: 4px;
+}
+
+.tab-more-item {
+  padding: 8px 12px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.tab-more-item[data-active='true'] {
+  color: var(--text);
+  background: var(--hover-wash);
+}
+
+.tab-more-item:hover {
+  background: var(--hover-wash);
 }
 
 .pane {
@@ -2149,51 +2206,469 @@ textarea {
   word-break: break-all;
 }
 
-/* --- Grouped action history ------------------------------------------------ */
+/* --- History tab ----------------------------------------------------------- */
 
-.history-group {
-  padding: 0;
-  overflow: hidden;
+.history-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
-.history-group-head {
+.history-tab .history-sections {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  margin: 0;
+  padding: 6px 0 4px;
+  background: var(--bg);
+}
+
+.record-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* Sticky batch toolbar ----------------------------------------------------- */
+
+.record-batchbar {
+  position: sticky;
+  top: 33px; /* below the sub-section tab strip */
+  z-index: 2;
   display: flex;
   align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 9px 12px;
-  border: 0;
-  background: transparent;
-  color: var(--text);
-  text-align: left;
-  cursor: pointer;
-  font: inherit;
+  gap: 10px;
+  padding: 7px 10px;
+  margin: 0;
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: 0 1px 0 var(--border);
 }
 
-.history-group-head:hover {
-  background: var(--hover-wash);
-}
-
-.history-caret {
+.record-batchbar-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
   color: var(--muted);
-  width: 12px;
+  cursor: pointer;
+  margin: 0;
+  white-space: nowrap;
+  flex: none;
 }
 
-.history-group-title {
+.record-batchbar-check input {
+  margin: 0;
+  accent-color: var(--accent);
+  flex: none;
+}
+
+.record-batchbar-count {
   flex: 1;
+  font-size: 11px;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.record-batchbar-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.record-batchbar button {
+  padding: 4px 10px;
+  font-size: 12px;
+  border-radius: 6px;
+}
+
+.record-batchbar button.ghost {
+  background: transparent;
+  color: var(--muted);
+  border-color: transparent;
+}
+
+.record-batchbar button.ghost:hover:not(:disabled) {
+  color: var(--err);
+  background: var(--err-surface);
+}
+
+/* Record cards ------------------------------------------------------------- */
+
+.record-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+
+.record-card:hover {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+}
+
+.record-head {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 10px;
+  cursor: pointer;
+  user-select: none;
+  outline: none;
+}
+
+.record-head:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--accent-soft-border);
+  border-radius: 10px;
+}
+
+.record-head input[type='checkbox'].record-check {
+  width: 14px;
+  height: 14px;
+  margin: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+/* Caret drawn as a CSS triangle so it lines up crisply at any DPI. */
+.record-caret {
+  width: 14px;
+  height: 14px;
+  position: relative;
+  flex: none;
+  color: var(--muted);
+  transition: transform 140ms ease;
+}
+
+.record-caret::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  transform: translate(-25%, -50%);
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 6px solid currentColor;
+}
+
+.record-caret.open {
+  transform: rotate(90deg);
+}
+
+.record-caret-spacer {
+  width: 14px;
+  height: 1px;
+  flex: none;
+}
+
+.record-title {
+  min-width: 0;
+  font-size: 13px;
   font-weight: 600;
+  color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.record-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  flex: none;
+}
+
+.record-source {
+  font-size: 10px;
+  color: var(--muted);
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--chip);
+  white-space: nowrap;
+}
+
+.record-time {
+  font-size: 11px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+/* Action icon buttons inside history record rows (delete, rebuild workflow).
+   Scoped to `.record-card` / `.history-step` so we don't hide unrelated
+   `.icon-btn` usages elsewhere (e.g. the mode-info "?" next to the chat
+   mode selector). These reveal on hover/focus of the row. */
+.record-card .icon-btn,
+.history-step .icon-btn {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0;
+  font-size: 15px;
+  line-height: 1;
+  flex: none;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease, background 120ms ease, color 120ms ease;
+}
+
+.record-head:hover .icon-btn,
+.record-head:focus-within .icon-btn,
+.record-card:hover .record-head .icon-btn,
+.history-step:hover .icon-btn,
+.history-step:focus-within .icon-btn {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.record-card .icon-btn:hover,
+.history-step .icon-btn:hover {
+  background: var(--hover-wash);
+  color: var(--text);
+}
+
+.record-card .icon-btn.danger:hover,
+.history-step .icon-btn.danger:hover {
+  background: var(--err-surface);
+  color: var(--err);
+}
+
+.record-delete {
+  /* uses the scoped .record-card .icon-btn rule above */
+}
+
+.history-rebuild.icon-btn {
+  font-size: 14px;
+}
+
+.record-summary {
+  font-size: 12px;
+  color: var(--muted);
+  padding: 0 12px 9px 46px; /* align under the title column */
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+}
+
+.record-detail {
+  border-top: 1px solid var(--border);
+  background: var(--sunken);
+  padding: 10px 12px 12px 46px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Outcome badge shared by workflow/task run cards. */
+.status-badge {
+  flex: none;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 8px;
+  height: 18px;
+  line-height: 16px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.status-badge.ok {
+  background: var(--ok-surface);
+  color: var(--ok);
+}
+
+.status-badge.err {
+  background: var(--err-surface);
+  color: var(--err);
+}
+
+.status-badge.cancel {
+  background: var(--warn-surface);
+  color: var(--warn);
+}
+
+.status-badge.skip {
+  background: var(--warn-surface);
+  color: var(--warn);
+}
+
+/* Conversation transcripts ------------------------------------------------ */
+
+.conv-msgs {
+  gap: 6px;
+}
+
+.record-msg {
+  font-size: 12px;
+  line-height: 1.5;
+  padding: 6px 10px;
+  border-radius: 8px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.record-msg-user {
+  align-self: flex-end;
+  background: var(--user-bubble);
+  color: var(--text);
+  max-width: 86%;
+  margin-left: 28px;
+}
+
+.record-msg-assistant {
+  align-self: flex-start;
+  background: var(--panel-2);
+  color: var(--text);
+  max-width: 94%;
+  margin-right: 12px;
+}
+
+.record-msg-tool {
+  align-self: flex-start;
+  background: var(--chip);
+  color: var(--muted);
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
+  max-width: 94%;
+  margin-right: 12px;
+}
+
+/* Run steps ---------------------------------------------------------------- */
+
+.record-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.record-step {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+  line-height: 1.5;
+  border-left: 2px solid var(--border);
+  padding: 2px 0 2px 10px;
+}
+
+.record-step[data-kind='error'] {
+  border-left-color: var(--err);
+}
+
+.record-step[data-kind='tool'] {
+  border-left-color: var(--accent);
+}
+
+.record-step-time {
+  font-size: 10px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.record-step-tag {
+  font-size: 9px;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding: 0 6px;
+  height: 16px;
+  line-height: 16px;
+  border-radius: 999px;
+  background: var(--chip);
+  white-space: nowrap;
+}
+
+.record-step-text {
+  min-width: 0;
+  word-break: break-word;
+}
+
+.record-error {
+  font-size: 12px;
+  color: var(--err);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--err);
+  border-radius: 6px;
+  padding: 6px 8px;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+/* Failure detail shown on a collapsed run row so broken runs are visible
+   without expanding every failed card. */
+.record-error-inline {
+  font-size: 11px;
+  color: var(--err);
+  background: var(--err-surface);
+  border-radius: 6px;
+  padding: 6px 10px;
+  margin: 0 10px 9px 46px;
+  word-break: break-word;
+  white-space: pre-wrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* "Continue chat" CTA at the bottom of an expanded conversation. */
+.conv-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+.conv-continue {
+  padding: 5px 14px;
+  font-size: 12px;
+  border-radius: 6px;
+}
+
+/* Grouped action history --------------------------------------------------- */
+
+.history-group {
+  padding: 0;
+}
+
+.history-group-head {
+  cursor: pointer;
+}
+
+.history-group-title {
+  font-weight: 600;
 }
 
 .history-count {
   font-size: 10px;
   font-weight: 600;
   padding: 0 7px;
+  height: 16px;
+  line-height: 16px;
   border-radius: 999px;
   background: var(--chip);
   color: var(--muted);
+  min-width: 20px;
+  text-align: center;
 }
 
 .history-stat {
@@ -2209,18 +2684,24 @@ textarea {
   color: var(--err);
 }
 
+.history-rebuild.icon-btn {
+  font-size: 14px;
+}
+
 .history-steps {
   list-style: none;
   margin: 0;
-  padding: 0 12px 10px;
+  padding: 0 10px 10px 46px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
 .history-step {
   border-left: 2px solid var(--border);
-  padding: 4px 0 4px 10px;
+  padding: 6px 8px 6px 10px;
+  border-radius: 0 8px 8px 0;
+  background: var(--sunken);
 }
 
 .history-step-ok {
@@ -2232,21 +2713,39 @@ textarea {
 }
 
 .history-step-head {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
   font-size: 11px;
   color: var(--muted);
 }
 
+.history-step-head .record-check {
+  width: 13px;
+  height: 13px;
+}
+
 .history-step-time {
   white-space: nowrap;
+  font-size: 10px;
+  color: var(--muted);
+}
+
+.history-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  justify-self: end;
 }
 
 .history-host {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  max-width: 120px;
+  font-size: 10px;
 }
 
 .history-declined {
@@ -2256,24 +2755,20 @@ textarea {
   letter-spacing: 0.04em;
 }
 
-.history-delete {
-  margin-left: auto;
-  padding: 0 6px;
-  font-size: 14px;
-  line-height: 1;
-}
-
 .history-summary {
   font-size: 12px;
-  margin-top: 2px;
+  margin-top: 4px;
+  color: var(--text);
+  word-break: break-word;
 }
 
 .history-detail {
   list-style: none;
-  margin: 4px 0 0;
+  margin: 6px 0 0;
   padding: 6px 8px;
-  border-radius: 4px;
-  background: var(--sunken);
+  border-radius: 6px;
+  background: var(--panel);
+  border: 1px solid var(--border);
   font-family: ui-monospace, monospace;
   font-size: 11px;
   line-height: 1.5;
@@ -2286,3 +2781,35 @@ textarea {
 .history-detail li {
   color: var(--muted);
 }
+
+/* JSON arguments dump ----------------------------------------------------- */
+
+.record-args {
+  margin-top: 4px;
+}
+
+.record-json-label {
+  display: block;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+
+.record-json {
+  margin: 0;
+  padding: 8px;
+  border-radius: 6px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 220px;
+  overflow: auto;
+  color: var(--text);
+}
+

--- a/src/workflow-editor/App.tsx
+++ b/src/workflow-editor/App.tsx
@@ -1,0 +1,831 @@
+import { useCallback, useEffect, useState, useMemo, memo } from 'react'
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  Handle,
+  Position,
+  type Node,
+  type Edge,
+  type Connection,
+  type NodeTypes,
+  type NodeChange,
+  type EdgeChange,
+  useReactFlow,
+  applyNodeChanges,
+  applyEdgeChanges,
+} from '@xyflow/react'
+import {
+  WORKFLOW_BLOCKS,
+  BLOCK_CATEGORIES,
+  BLOCK_BY_ID,
+} from '../lib/workflow/registry'
+import type {
+  Workflow,
+  WorkflowNode,
+  WorkflowEdge,
+  WorkflowTrigger,
+  WorkflowSettings,
+  BlockDefinition,
+  ParamDefinition,
+} from '../lib/workflow/types'
+import { sendCommand } from '../lib/messages'
+import { newId } from '../lib/storage'
+import CodeInput from './CodeInput'
+
+const CATEGORY_LABELS: Record<string, string> = {
+  browser: '浏览',
+  navigation: '导航',
+  data: '数据',
+  'control-flow': '流程控制',
+  integration: '集成',
+  trigger: '触发器',
+}
+
+/** Variables the engine exposes by default (see executors / engine loop blocks). */
+const BUILTIN_VARIABLES = [
+  'loopIndex',
+  'loopItem',
+  'lastText',
+  'lastValue',
+  'lastResult',
+  'lastAIResponse',
+  'lastExport',
+  'dataTable',
+  'refData',
+]
+
+const VAR_TOKEN = /\{\{\s*([^{}]+?)\s*\}\}/g
+
+const TRIGGER_LABELS: Record<string, string> = {
+  manual: '手动运行',
+  scheduled: '定时运行',
+  'context-menu': '右键菜单',
+  'visit-web': '访问网址',
+  github: 'GitHub',
+  feishu: '飞书',
+}
+
+const DEFAULT_SETTINGS: WorkflowSettings = {
+  saveLog: false,
+  debugMode: false,
+  notification: false,
+  reuseLastState: false,
+}
+
+function defaultsFromParams(params?: ParamDefinition[]): Record<string, unknown> {
+  const defaults: Record<string, unknown> = {}
+  if (!params) return defaults
+  for (const param of params) {
+    if (param.default !== undefined) {
+      defaults[param.name] = param.default
+    } else {
+      switch (param.type) {
+        case 'number':
+          defaults[param.name] = 0
+          break
+        case 'boolean':
+          defaults[param.name] = false
+          break
+        case 'select':
+          defaults[param.name] = param.options?.[0] ?? ''
+          break
+        case 'json':
+          defaults[param.name] = '{}'
+          break
+        case 'string':
+        default:
+          defaults[param.name] = ''
+          break
+      }
+    }
+  }
+  return defaults
+}
+
+interface CustomNodeData extends Record<string, unknown> {
+  blockId: string
+  values: Record<string, unknown>
+  /** Optional display label; falls back to the block label. */
+  label?: string
+}
+
+type CustomNode = Node<CustomNodeData>
+
+function CustomNodeComponent({ data, selected }: { data: CustomNodeData; selected: boolean }) {
+  const block = BLOCK_BY_ID.get(data.blockId)
+  return (
+    <div className={`custom-node ${selected ? 'selected' : ''}`}>
+      <Handle type="target" position={Position.Top} />
+      <div className="custom-node-header">
+        <div className="custom-node-label">{data.label || block?.label || data.blockId}</div>
+      </div>
+      {selected && (
+        <div className="custom-node-body">
+          <div className="custom-node-id">id: {data.blockId}</div>
+        </div>
+      )}
+      <Handle type="source" position={Position.Bottom} />
+    </div>
+  )
+}
+
+const nodeTypes: NodeTypes = {
+  custom: CustomNodeComponent,
+}
+
+/**
+ * The right-side parameter form for whichever node is selected.
+ *
+ * Memoized so dragging other nodes around on the canvas (which rebuilds every
+ * node object) doesn't re-render the form — only the selected node's data or
+ * the available-variable list does. That keeps typing into a field smooth and
+ * prevents the inspector from visibly lagging a node switch.
+ */
+interface NodeInspectorProps {
+  node: CustomNode | undefined
+  block: BlockDefinition | undefined
+  values: Record<string, unknown>
+  availableVariables: string[]
+  onValueChange: (paramName: string, value: unknown) => void
+  onLabelChange: (label: string) => void
+  onInsertVariable: (paramName: string, varName: string) => void
+}
+
+const NodeInspector = memo(function NodeInspector({
+  node,
+  block,
+  values,
+  availableVariables,
+  onValueChange,
+  onLabelChange,
+  onInsertVariable,
+}: NodeInspectorProps) {
+  if (!node) {
+    return <div className="inspector-empty">点击画布上的节点以编辑参数</div>
+  }
+
+  const renderParamInput = (
+    param: ParamDefinition,
+    value: unknown,
+    withVariableInsert?: boolean,
+  ) => {
+    const onChange = (newValue: unknown): void => onValueChange(param.name, newValue)
+    // JavaScript snippets (JS 代码 / 条件 / 循环条件等) use a highlighted editor.
+    if (param.name === 'code') {
+      return (
+        <CodeInput
+          value={(value as string) ?? ''}
+          onChange={(v) => onChange(v)}
+          placeholder={param.label || param.name}
+        />
+      )
+    }
+    switch (param.type) {
+      case 'number':
+        return (
+          <input
+            type="number"
+            value={Number(value) ?? 0}
+            onChange={(e) => onChange(Number(e.target.value))}
+          />
+        )
+      case 'boolean':
+        return (
+          <label className="checkbox-label">
+            <input
+              type="checkbox"
+              checked={Boolean(value)}
+              onChange={(e) => onChange(e.target.checked)}
+            />
+            {param.label || param.name}
+          </label>
+        )
+      case 'select':
+        return (
+          <select value={(value as string) ?? ''} onChange={(e) => onChange(e.target.value)}>
+            {param.options?.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+        )
+      case 'json':
+        return (
+          <textarea
+            value={(value as string) ?? '{}'}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder="{}"
+          />
+        )
+      case 'string':
+      default:
+        return (
+          <div className="var-field-wrap">
+            <input
+              type="text"
+              value={(value as string) ?? ''}
+              onChange={(e) => onChange(e.target.value)}
+              placeholder={param.label || param.name}
+            />
+            {withVariableInsert && (
+              <select
+                className="var-insert-select"
+                aria-label="插入变量"
+                value=""
+                onChange={(e) => {
+                  if (e.target.value) onInsertVariable(param.name, e.target.value)
+                }}
+              >
+                <option value="">+ 变量</option>
+                {availableVariables.map((name) => (
+                  <option key={name} value={name}>
+                    {`{{${name}}}`}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+        )
+    }
+  }
+
+  return (
+    <div className="inspector-section inspector-node">
+      <h3>节点参数 · {block?.label ?? node.data.blockId}</h3>
+      <div className="param-group">
+        <label>节点名称</label>
+        <input
+          type="text"
+          value={node.data.label || ''}
+          onChange={(e) => onLabelChange(e.target.value)}
+          placeholder={block?.label ?? node.data.blockId}
+        />
+        <div className="param-desc">留空则使用该块类型的默认名称</div>
+      </div>
+      {!block ? (
+        <div className="inspector-empty" style={{ padding: '8px 0' }}>
+          未知节点类型：{node.data.blockId}
+        </div>
+      ) : !block.params || block.params.length === 0 ? (
+        <div className="inspector-empty" style={{ padding: '8px 0' }}>
+          此节点没有可配置参数
+        </div>
+      ) : (
+        block.params.map((param) => (
+          <div key={param.name} className="param-group">
+            {param.type !== 'boolean' && (
+              <label>
+                {param.label || param.name}
+                {param.required && ' *'}
+              </label>
+            )}
+            {renderParamInput(
+              param,
+              values[param.name],
+              true,
+            )}
+            {param.description && <div className="param-desc">{param.description}</div>}
+          </div>
+        ))
+      )}
+    </div>
+  )
+})
+
+export default function EditorApp() {
+  const [workflowId, setWorkflowId] = useState<string | null>(null)
+  const [workflowName, setWorkflowName] = useState<string>('新工作流')
+  const [nodes, setNodes] = useState<CustomNode[]>([])
+  const [edges, setEdges] = useState<Edge[]>([])
+  const [trigger, setTrigger] = useState<WorkflowTrigger>({ type: 'manual', enabled: true })
+  const [settings] = useState<WorkflowSettings>(DEFAULT_SETTINGS)
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
+  const [searchText, setSearchText] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [running, setRunning] = useState(false)
+  const [lastSaved, setLastSaved] = useState<Date | null>(null)
+  const [errorBanner, setErrorBanner] = useState<string | null>(null)
+
+  const reactFlow = useReactFlow()
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const editId = params.get('edit')
+    if (editId) {
+      void loadExistingWorkflow(editId)
+    } else {
+      const id = newId()
+      setWorkflowId(id)
+      setWorkflowName('新工作流')
+      setLastSaved(null)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const loadExistingWorkflow = async (id: string): Promise<void> => {
+    try {
+      const result = await sendCommand({ type: 'workflows.get', id })
+      if (result.type === 'workflows.get' && result.workflow) {
+        const wf = result.workflow
+        setWorkflowId(wf.id)
+        setWorkflowName(wf.name)
+        const flowNodes: CustomNode[] = wf.drawflow.nodes.map((n) => ({
+          id: n.id,
+          type: 'custom',
+          position: n.position,
+          data: {
+            blockId:
+              (n.data.blockId as string | undefined) ?? 'unknown',
+            values: n.data.values
+              ? (n.data.values as Record<string, unknown>)
+              : n.data,
+            ...(n.label ? { label: n.label } : {}),
+          },
+        }))
+        const flowEdges: Edge[] = wf.drawflow.edges.map((e) => ({
+          id: e.id,
+          source: e.source,
+          target: e.target,
+          sourceHandle: e.sourceHandle,
+          targetHandle: e.targetHandle,
+        }))
+        setNodes(flowNodes)
+        setEdges(flowEdges)
+        if (wf.trigger) setTrigger(wf.trigger)
+        setLastSaved(new Date())
+        if (wf.drawflow.position && typeof wf.drawflow.zoom === 'number') {
+          const { position, zoom } = wf.drawflow
+          window.setTimeout(() => {
+            reactFlow.setViewport({
+              x: position?.x ?? 0,
+              y: position?.y ?? 0,
+              zoom,
+            })
+          }, 0)
+        }
+      }
+    } catch (err) {
+      setErrorBanner(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const onNodesChange = useCallback((changes: NodeChange<CustomNode>[]) => {
+    setNodes((nds) => applyNodeChanges<CustomNode>(changes, nds))
+    // XYFlow emits a batch of select changes when the user clicks a different
+    // node (deselect old, select new) in a single dispatch. Process the whole
+    // batch so the inspector jumps straight to the new node instead of briefly
+    // rendering the empty state — that flash was the visible "wrong panel".
+    let nextId: string | null | undefined
+    for (const c of changes) {
+      if (c.type !== 'select') continue
+      if (c.selected) {
+        nextId = c.id
+      } else if (nextId === undefined || nextId === c.id) {
+        nextId = null
+      }
+    }
+    if (nextId !== undefined) setSelectedNodeId(nextId)
+  }, [])
+
+  const onEdgesChange = useCallback(
+    (changes: EdgeChange[]) => {
+      setEdges((eds) => applyEdgeChanges(changes, eds))
+    },
+    [],
+  )
+
+  const onConnect = useCallback((connection: Connection) => {
+    if (!connection.source || !connection.target) return
+    setEdges((eds) => [
+      ...eds,
+      {
+        id: newId(),
+        source: connection.source!,
+        target: connection.target!,
+        sourceHandle: connection.sourceHandle,
+        targetHandle: connection.targetHandle,
+        type: 'smoothstep',
+      },
+    ])
+  }, [])
+
+  const isValidConnection = useCallback(
+    (connection: Connection | Edge): boolean => {
+      const source = connection.source
+      const target = connection.target
+      if (!source || !target) return false
+      // Forbid self-connection and multiple incoming edges per target.
+      return source !== target && !edges.some((e) => e.target === target)
+    },
+    [edges],
+  )
+
+  const onDrop = useCallback(
+    (event: React.DragEvent) => {
+      event.preventDefault()
+      const blockId = event.dataTransfer.getData('application/workflow-block')
+      if (!blockId) return
+      const block = BLOCK_BY_ID.get(blockId)
+      if (!block) return
+      const position = reactFlow.screenToFlowPosition({
+        x: event.clientX,
+        y: event.clientY,
+      })
+      const newNode: CustomNode = {
+        id: newId(),
+        type: 'custom',
+        position,
+        data: {
+          blockId: block.id,
+          values: defaultsFromParams(block.params),
+        },
+      }
+      setNodes((nds) => [...nds, newNode])
+    },
+    [reactFlow],
+  )
+
+  const onDragOver = useCallback((event: React.DragEvent) => {
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'copy'
+  }, [])
+
+  const onNodesDelete = useCallback((deleted: Node[]) => {
+    const ids = new Set(deleted.map((n) => n.id))
+    setSelectedNodeId((current) => (current && ids.has(current) ? null : current))
+  }, [])
+
+  const handleSave = useCallback(async () => {
+    if (!workflowId) return
+    setSaving(true)
+    setErrorBanner(null)
+    try {
+      const { x, y, zoom } = reactFlow.getViewport()
+      const nodesWorkflow: WorkflowNode[] = nodes.map((n) => ({
+        id: n.id,
+        label: n.data.label || BLOCK_BY_ID.get(n.data.blockId)?.label || n.data.blockId,
+        position: n.position,
+        data: {
+          blockId: n.data.blockId,
+          values: n.data.values,
+        },
+      }))
+      const edgesWorkflow: WorkflowEdge[] = edges.map((e) => ({
+        id: e.id,
+        source: e.source,
+        target: e.target,
+        sourceHandle: e.sourceHandle ?? undefined,
+        targetHandle: e.targetHandle ?? undefined,
+      }))
+      const flowWorkflow: Workflow = {
+        id: workflowId,
+        name: workflowName,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        drawflow: {
+          nodes: nodesWorkflow,
+          edges: edgesWorkflow,
+          position: { x, y },
+          zoom,
+        },
+        trigger,
+        settings,
+      }
+      await sendCommand({ type: 'workflows.save', workflow: flowWorkflow })
+      setLastSaved(new Date())
+    } catch (err) {
+      setErrorBanner(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }, [workflowId, workflowName, nodes, edges, trigger, settings, reactFlow])
+
+  const handleRun = useCallback(async () => {
+    if (!workflowId) return
+    await handleSave()
+    setRunning(true)
+    setErrorBanner(null)
+    try {
+      const result = await sendCommand({ type: 'workflows.run', id: workflowId })
+      if (result.type === 'workflows.run') {
+        if (result.outcome.ok) {
+          alert(`运行成功：${result.outcome.summary || '完成'}`)
+        } else {
+          alert(`运行失败：${result.outcome.error ?? result.outcome.summary}`)
+        }
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      setErrorBanner(msg)
+      alert(`运行出错：${msg}`)
+    } finally {
+      setRunning(false)
+    }
+  }, [workflowId, handleSave])
+
+  const selectedNode = useMemo(
+    () => nodes.find((n) => n.id === selectedNodeId),
+    [nodes, selectedNodeId],
+  )
+
+  const updateSelectedNodeValue = useCallback(
+    (paramName: string, value: unknown) => {
+      if (!selectedNodeId) return
+      setNodes((nds) =>
+        nds.map((n) => {
+          if (n.id !== selectedNodeId) return n
+          return {
+            ...n,
+            data: {
+              ...n.data,
+              values: {
+                ...n.data.values,
+                [paramName]: value,
+              },
+            },
+          }
+        }),
+      )
+    },
+    [selectedNodeId],
+  )
+
+  const updateSelectedNodeLabel = useCallback(
+    (label: string) => {
+      if (!selectedNodeId) return
+      setNodes((nds) =>
+        nds.map((n) => {
+          if (n.id !== selectedNodeId) return n
+          return { ...n, data: { ...n.data, label } }
+        }),
+      )
+    },
+    [selectedNodeId],
+  )
+
+  const filteredBlocks = useMemo(() => {
+    if (!searchText) return WORKFLOW_BLOCKS
+    const q = searchText.toLowerCase()
+    return WORKFLOW_BLOCKS.filter(
+      (b) =>
+        b.id.toLowerCase().includes(q) ||
+        (b.label ?? '').toLowerCase().includes(q) ||
+        (b.description ?? '').toLowerCase().includes(q),
+    )
+  }, [searchText])
+
+  const blocksByCategory = useMemo(() => {
+    const grouped = new Map<string, BlockDefinition[]>()
+    for (const cat of BLOCK_CATEGORIES) grouped.set(cat, [])
+    for (const block of filteredBlocks) {
+      const list = grouped.get(block.category)
+      if (list) list.push(block)
+    }
+    return Array.from(grouped.entries()).filter(([, blocks]) => blocks.length > 0)
+  }, [filteredBlocks])
+
+  // Only the *string contents* of node values can contribute a `{{var}}`.
+  // Position changes (dragging) rebuild every node object but shouldn't force
+  // a regex scan across the whole graph, so the memo keys off a compact
+  // signature of those string values.
+  const variableSignature = useMemo(() => {
+    const parts: string[] = []
+    for (const n of nodes) {
+      const values = (n.data.values ?? {}) as Record<string, unknown>
+      for (const v of Object.values(values)) {
+        if (typeof v === 'string' && v.includes('{{')) parts.push(v)
+      }
+    }
+    return parts.join('\u0000')
+  }, [nodes])
+
+  const availableVariables = useMemo(() => {
+    const set = new Set<string>(BUILTIN_VARIABLES)
+    VAR_TOKEN.lastIndex = 0
+    let m: RegExpExecArray | null
+    while ((m = VAR_TOKEN.exec(variableSignature)) !== null) {
+      const before = (m[1] ?? '').trim()
+      if (before) set.add(before)
+    }
+    return Array.from(set)
+  }, [variableSignature])
+
+  /** Appends `{{varName}}` to a selected node's parameter value. */
+  const insertVariableInto = useCallback(
+    (paramName: string, varName: string): void => {
+      if (!selectedNode) return
+      const current = (selectedNode.data.values[paramName] as string | undefined) ?? ''
+      updateSelectedNodeValue(paramName, `${current}{{${varName}}}`)
+    },
+    [selectedNode, updateSelectedNodeValue],
+  )
+
+  const triggerTypes: WorkflowTrigger['type'][] = [
+    'manual',
+    'scheduled',
+    'context-menu',
+    'visit-web',
+    'github',
+    'feishu',
+  ]
+
+  const selectedBlock = selectedNode ? BLOCK_BY_ID.get(selectedNode.data.blockId) : undefined
+
+  return (
+    <div className="editor-layout">
+      <div className="editor-topbar">
+        <div className="workflow-name">
+          <input
+            type="text"
+            value={workflowName}
+            onChange={(e) => setWorkflowName(e.target.value)}
+            placeholder="工作流名称"
+          />
+        </div>
+        <div className={`save-status ${lastSaved && !saving ? 'saved' : ''}`}>
+          {saving ? '保存中...' : lastSaved ? '已保存' : '未保存'}
+        </div>
+        <button className="primary" type="button" onClick={() => void handleSave()} disabled={saving || running}>
+          保存
+        </button>
+        <button className="primary" type="button" onClick={() => void handleRun()} disabled={saving || running}>
+          运行
+        </button>
+      </div>
+
+      <div className="editor-palette">
+        <div className="palette-search">
+          <input
+            type="text"
+            placeholder="搜索节点..."
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+          />
+        </div>
+        <div className="palette-categories">
+          {blocksByCategory.map(([category, blocks]) => (
+            <div key={category} className="palette-category">
+              <h4>{CATEGORY_LABELS[category] ?? category}</h4>
+              {blocks.map((block) => (
+                <div
+                  key={block.id}
+                  className="palette-block"
+                  draggable
+                  onDragStart={(e) => {
+                    e.dataTransfer.setData('application/workflow-block', block.id)
+                    e.dataTransfer.effectAllowed = 'copy'
+                  }}
+                >
+                  <div className="block-label">{block.label || block.id}</div>
+                  {block.description && <div className="block-desc">{block.description}</div>}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="editor-canvas">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          isValidConnection={isValidConnection}
+          nodeTypes={nodeTypes}
+          onDrop={onDrop}
+          onDragOver={onDragOver}
+          onNodesDelete={onNodesDelete}
+          fitView={!workflowId}
+          deleteKeyCode="Delete"
+          multiSelectionKeyCode="Control"
+          defaultEdgeOptions={{ type: 'smoothstep' }}
+        >
+          <Background gap={16} />
+          <Controls />
+          <MiniMap pannable zoomable />
+        </ReactFlow>
+      </div>
+
+      <div className="editor-inspector">
+        {errorBanner && (
+          <div className="inspector-section error-banner">
+            <h3>错误</h3>
+            <div className="error-text">{errorBanner}</div>
+          </div>
+        )}
+
+        <NodeInspector
+          node={selectedNode}
+          block={selectedBlock}
+          values={selectedNode?.data.values ?? {}}
+          availableVariables={availableVariables}
+          onValueChange={updateSelectedNodeValue}
+          onLabelChange={updateSelectedNodeLabel}
+          onInsertVariable={insertVariableInto}
+        />
+
+        <div className="inspector-section">
+          <h3>工作流变量</h3>
+          <div className="param-desc" style={{ marginBottom: 8 }}>
+            参数中可用 <code>{'{'}</code>{'{变量名}'}{'}'} 引用前面算子传递的变量；此处列出引擎内置变量与当前工作流中已出现的变量。
+          </div>
+          <div className="var-list">
+            {availableVariables.length === 0 ? (
+              <div className="inspector-empty">暂无变量</div>
+            ) : (
+              availableVariables.map((name) => (
+                <span
+                  key={name}
+                  className="var-chip"
+                  title="复制变量名"
+                  onClick={() => void navigator.clipboard?.writeText(`{{${name}}}`)}
+                >
+                  {'{{'}
+                  {name}
+                  {'}}'}
+                </span>
+              ))
+            )}
+          </div>
+        </div>
+
+        {(!selectedNode || selectedBlock?.category === 'trigger') && (
+        <div className="inspector-section">
+          <h3>触发器设置</h3>
+          <div className="param-group">
+            <label>触发类型</label>
+            <select
+              value={trigger.type}
+              onChange={(e) =>
+                setTrigger({
+                  type: e.target.value as WorkflowTrigger['type'],
+                  enabled: trigger.enabled ?? true,
+                })
+              }
+            >
+              {triggerTypes.map((t) => (
+                <option key={t} value={t}>
+                  {TRIGGER_LABELS[t] ?? t}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="param-group">
+            <label className="checkbox-label">
+              <input
+                type="checkbox"
+                checked={trigger.enabled ?? false}
+                onChange={(e) => setTrigger({ ...trigger, enabled: e.target.checked })}
+              />
+              启用触发器
+            </label>
+          </div>
+
+          {trigger.type === 'scheduled' && (
+            <div className="param-group">
+              <label>时间表达式</label>
+              <input
+                type="text"
+                value={trigger.schedule || ''}
+                onChange={(e) => setTrigger({ ...trigger, schedule: e.target.value })}
+                placeholder="0 8 * * * (每天 8 点)"
+              />
+              <div className="param-desc">Cron 表达式，与定时任务格式一致</div>
+            </div>
+          )}
+
+          {trigger.type === 'visit-web' && (
+            <div className="param-group">
+              <label>URL 匹配</label>
+              <input
+                type="text"
+                value={trigger.urlPattern || ''}
+                onChange={(e) => setTrigger({ ...trigger, urlPattern: e.target.value })}
+                placeholder="https://example.com/*"
+              />
+            </div>
+          )}
+
+          {trigger.type === 'context-menu' && (
+            <div className="param-group">
+              <label>菜单项 ID</label>
+              <input
+                type="text"
+                value={trigger.menuItemId || ''}
+                onChange={(e) => setTrigger({ ...trigger, menuItemId: e.target.value })}
+                placeholder="留空自动使用工作流 ID"
+              />
+            </div>
+          )}
+        </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/workflow-editor/CodeInput.tsx
+++ b/src/workflow-editor/CodeInput.tsx
@@ -1,0 +1,116 @@
+/**
+ * CodeInput: a highlighted JavaScript code editor.
+ *
+ * Plain `<textarea>` semantics (native copy/paste, selection, undo) with a
+ * syntax-highlighted `<pre>` rendered behind it. The textarea draws a visible
+ * caret but transparent text so the highlight shows through; scroll and line
+ * metrics are identical for both layers so tokens stay aligned.
+ *
+ * No external highlighter dependency — the tokenizer is deliberately small and
+ * good enough for workflow snippets (keywords, strings, comments, numbers, and
+ * `{{variable}}` tokens).
+ *
+ * @module workflow-editor/CodeInput
+ */
+import { useMemo, useRef } from 'react'
+
+const KEYWORDS = new Set([
+  'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger', 'default',
+  'delete', 'do', 'else', 'export', 'extends', 'finally', 'for', 'function',
+  'if', 'import', 'in', 'instanceof', 'let', 'new', 'return', 'super', 'switch',
+  'this', 'throw', 'try', 'typeof', 'var', 'void', 'while', 'with', 'yield',
+  'await', 'async', 'true', 'false', 'null', 'undefined', 'of',
+])
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/ /g, '\u00a0')
+}
+
+interface HighlightedLine {
+  html: string
+}
+
+/** Tokenizes one line of JavaScript into a highlighted HTML string. */
+function highlightLine(line: string): string {
+  const out: string[] = []
+
+  // Split line into: comments, strings, tokens/variables, and the rest.
+  const re = /(\/\/[^\n]*)|("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`(?:[^`\\]|\\.)*`)|\{\{\s*[\w.-]+\s*\}\}|([A-Za-z_$][\w$]*)|(\b\d+(?:\.\d+)?\b)/g
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = re.exec(line)) !== null) {
+    if (match.index > lastIndex) {
+      out.push(escapeHtml(line.slice(lastIndex, match.index)))
+    }
+    const [whole, comment, strng, token, number] = match
+    if (comment !== undefined) {
+      out.push(`<span class="tok-comment">${escapeHtml(whole)}</span>`)
+    } else if (strng !== undefined) {
+      out.push(`<span class="tok-string">${escapeHtml(whole)}</span>`)
+    } else if (token !== undefined) {
+      out.push(
+        `<span class="${KEYWORDS.has(token) ? 'tok-keyword' : 'tok-name'}">${escapeHtml(whole)}</span>`,
+      )
+    } else if (number !== undefined) {
+      out.push(`<span class="tok-number">${escapeHtml(whole)}</span>`)
+    } else {
+      out.push(`<span class="tok-token">${escapeHtml(whole)}</span>`)
+    }
+    lastIndex = re.lastIndex
+  }
+  if (lastIndex < line.length) {
+    out.push(escapeHtml(line.slice(lastIndex)))
+  }
+  return out.join('')
+}
+
+export default function CodeInput({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+}) {
+  const preRef = useRef<HTMLPreElement>(null)
+  const taRef = useRef<HTMLTextAreaElement>(null)
+
+  const highlighted = useMemo(
+    () => value.split('\n').map((line): HighlightedLine => ({ html: highlightLine(line) || '\u00a0' })),
+    [value],
+  )
+
+  const syncScroll = (): void => {
+    if (preRef.current && taRef.current) {
+      preRef.current.scrollTop = taRef.current.scrollTop
+      preRef.current.scrollLeft = taRef.current.scrollLeft
+    }
+  }
+
+  return (
+    <div className="code-input">
+      <pre ref={preRef} className="code-highlight" aria-hidden="true">
+        {highlighted.map((line, index) => (
+          <div key={index} dangerouslySetInnerHTML={{ __html: line.html }} />
+        ))}
+      </pre>
+      <textarea
+        ref={taRef}
+        className="code-write"
+        value={value}
+        placeholder={placeholder}
+        spellCheck={false}
+        onInput={syncScroll}
+        onScroll={syncScroll}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    </div>
+  )
+}

--- a/src/workflow-editor/index.html
+++ b/src/workflow-editor/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Workflow Editor — Browser Copilot</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      body {
+        margin: 0;
+        background: #14161a;
+        color: #e6e8ec;
+      }
+      @media (prefers-color-scheme: light) {
+        :root {
+          color-scheme: light;
+        }
+        body {
+          background: #ffffff;
+          color: #1b1f27;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/src/workflow-editor/main.tsx
+++ b/src/workflow-editor/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { ReactFlowProvider } from '@xyflow/react'
+import EditorApp from './App'
+import './styles.css'
+
+const container = document.getElementById('root')
+if (!container) throw new Error('Editor root element is missing.')
+
+createRoot(container).render(
+  <StrictMode>
+    <ReactFlowProvider>
+      <EditorApp />
+    </ReactFlowProvider>
+  </StrictMode>,
+)

--- a/src/workflow-editor/styles.css
+++ b/src/workflow-editor/styles.css
@@ -1,0 +1,454 @@
+@import '@xyflow/react/dist/style.css';
+
+:root {
+  --color-bg: #14161a;
+  --color-surface: #1e2128;
+  --color-border: #343946;
+  --color-text: #e6e8ec;
+  --color-text-secondary: #a8adb8;
+  --color-accent: #3b82f6;
+  --color-accent-hover: #2563eb;
+  --color-danger: #ef4444;
+  --color-danger-hover: #dc2626;
+  --color-success: #10b981;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --color-bg: #ffffff;
+    --color-surface: #f9fafb;
+    --color-border: #e5e7eb;
+    --color-text: #1b1f27;
+    --color-text-secondary: #6b7280;
+  }
+}
+
+body, html {
+  margin: 0;
+  padding: 0;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+#root {
+  height: 100%;
+  width: 100%;
+}
+
+.editor-layout {
+  display: grid;
+  grid-template-columns: 280px 1fr 320px;
+  grid-template-rows: 56px 1fr;
+  height: 100vh;
+  width: 100vw;
+}
+
+.editor-topbar {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 16px;
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.editor-topbar .workflow-name {
+  flex: 1;
+  min-width: 0;
+}
+
+.editor-topbar .workflow-name input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 14px;
+}
+
+.editor-topbar .save-status {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  min-width: 60px;
+}
+
+.editor-topbar .save-status.saved {
+  color: var(--color-success);
+}
+
+.editor-topbar button {
+  padding: 8px 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s;
+}
+
+.editor-topbar button:hover:not(:disabled) {
+  background: var(--color-bg);
+}
+
+.editor-topbar button.primary {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: white;
+}
+
+.editor-topbar button.primary:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+}
+
+.editor-topbar button.danger {
+  color: var(--color-danger);
+  border-color: var(--color-danger);
+}
+
+.editor-topbar button.danger:hover:not(:disabled) {
+  background: var(--color-danger);
+  color: white;
+}
+
+.editor-palette {
+  grid-column: 1;
+  grid-row: 2;
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.palette-search {
+  padding: 12px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.palette-search input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 14px;
+  box-sizing: border-box;
+}
+
+.palette-categories {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.palette-category {
+  margin-bottom: 16px;
+}
+
+.palette-category h4 {
+  margin: 0 0 8px 0;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-text-secondary);
+  padding: 0 4px;
+}
+
+.palette-block {
+  padding: 10px 12px;
+  margin-bottom: 6px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg);
+  cursor: grab;
+  transition: all 0.2s;
+}
+
+.palette-block:hover {
+  border-color: var(--color-accent);
+  background: var(--color-bg);
+  transform: translateY(-1px);
+}
+
+.palette-block:active {
+  cursor: grabbing;
+}
+
+.palette-block .block-label {
+  font-weight: 500;
+  font-size: 14px;
+  margin-bottom: 2px;
+}
+
+.palette-block .block-desc {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+}
+
+.editor-canvas {
+  grid-column: 2;
+  grid-row: 2;
+  background: var(--color-bg);
+}
+
+.editor-inspector {
+  grid-column: 3;
+  grid-row: 2;
+  background: var(--color-surface);
+  border-left: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.inspector-section {
+  padding: 16px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.inspector-section h3 {
+  margin: 0 0 12px 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.inspector-empty {
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--color-text-secondary);
+  font-size: 14px;
+}
+
+.param-group {
+  margin-bottom: 12px;
+}
+
+.param-group label {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.param-group input[type="text"],
+.param-group input[type="number"],
+.param-group select,
+.param-group textarea {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 14px;
+  box-sizing: border-box;
+}
+
+.param-group textarea {
+  min-height: 100px;
+  resize: vertical;
+  font-family: monospace;
+}
+
+.param-group input[type="checkbox"] {
+  margin-right: 8px;
+  transform: translateY(1px);
+}
+
+.param-group .checkbox-label {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.param-desc {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  margin-top: 2px;
+}
+
+.custom-node {
+  border: 2px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-surface);
+  min-width: 150px;
+}
+
+.custom-node.selected {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+.custom-node-header {
+  padding: 8px 12px;
+  background: var(--color-bg);
+  border-bottom: 1px solid var(--color-border);
+  border-radius: 6px 6px 0 0;
+}
+
+.custom-node-label {
+  font-weight: 500;
+  font-size: 13px;
+}
+
+.custom-node-body {
+  padding: 8px 12px;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.custom-node-id {
+  font-family: monospace;
+}
+
+.react-flow__node.selected {
+  box-shadow: none;
+}
+
+.react-flow__background {
+  background: var(--color-bg);
+}
+
+.react-flow__controls {
+  background: var(--color-surface);
+  border-color: var(--color-border);
+}
+
+.react-flow__controls-button {
+  background: var(--color-surface);
+  border-color: var(--color-border);
+  border-bottom-color: var(--color-border);
+}
+
+.react-flow__controls-button:hover {
+  background: var(--color-bg);
+}
+
+.react-flow__controls-button svg {
+  fill: var(--color-text);
+}
+
+/* --- Code input (textarea + highlighted overlay) --- */
+.code-input {
+  position: relative;
+  min-height: 120px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: #0f1115;
+  overflow: hidden;
+}
+
+.code-input pre,
+.code-input textarea {
+  margin: 0;
+  padding: 10px 12px;
+  border: 0;
+  width: 100%;
+  min-height: 120px;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  tab-size: 2;
+  white-space: pre;
+  box-sizing: border-box;
+  overflow: auto;
+}
+
+.code-input pre {
+  position: absolute;
+  top: 0;
+  left: 0;
+  color: #d6d9e0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.code-input textarea {
+  position: relative;
+  background: transparent;
+  color: transparent;
+  caret-color: #e6e8ec;
+  resize: vertical;
+  z-index: 1;
+}
+
+.code-input textarea::placeholder {
+  color: #5b6472;
+}
+
+.tok-keyword { color: #c678dd; }
+.tok-string  { color: #98c379; }
+.tok-number  { color: #d19a66; }
+.tok-comment { color: #7f848e; font-style: italic; }
+.tok-name    { color: #61afef; }
+.tok-token   { color: #e5c07b; }
+
+/* --- Variable helpers --- */
+.var-field-wrap {
+  position: relative;
+}
+
+.var-field-wrap input {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 14px;
+  box-sizing: border-box;
+  padding-right: 96px;
+}
+
+.var-insert-select {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 12px;
+  color: var(--color-accent);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 2px 4px;
+  max-width: 90px;
+  cursor: pointer;
+}
+
+.var-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.var-chip {
+  padding: 3px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-surface);
+  color: var(--color-accent);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.var-chip:hover {
+  border-color: var(--color-accent);
+}
+
+.inspector-section code {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  padding: 0 3px;
+  font-size: 12px;
+}

--- a/tests/workflow-engine.spec.ts
+++ b/tests/workflow-engine.spec.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { runWorkflow } from '../src/background/workflow-engine/engine'
+import { interpolate } from '../src/lib/workflow/interpolate'
+import type { Workflow, WorkflowEdge, WorkflowNode } from '../src/lib/workflow/types'
+
+/** Build a minimal Workflow from nodes + edges. */
+function makeWorkflow(nodes: WorkflowNode[], edges: WorkflowEdge[]): Workflow {
+  return {
+    id: 'wf',
+    name: 'wf',
+    createdAt: 0,
+    updatedAt: 0,
+    drawflow: { nodes, edges },
+    settings: {
+      saveLog: false,
+      debugMode: false,
+      notification: false,
+      reuseLastState: false,
+    },
+  }
+}
+
+const node = (id: string, label: string): WorkflowNode => ({
+  id,
+  label,
+  position: { x: 0, y: 0 },
+  data: {},
+})
+
+const edge = (source: string, target: string, handle?: string): WorkflowEdge => ({
+  id: `${source}->${target}`,
+  source,
+  target,
+  ...(handle ? { sourceHandle: handle } : {}),
+})
+
+/** An executor that just records it ran and follows the default edge. */
+function trace(label: string, order: string[]) {
+  return async () => {
+    order.push(label)
+    return null
+  }
+}
+
+describe('workflow engine', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('runs a linear a → b → c chain and reports completed node ids', async () => {
+    const order: string[] = []
+    const wf = makeWorkflow(
+      [node('a', 'step-a'), node('b', 'step-b'), node('c', 'step-c')],
+      [edge('a', 'b'), edge('b', 'c')],
+    )
+    const result = await runWorkflow(wf, {
+      executors: {
+        'step-a': trace('a', order),
+        'step-b': trace('b', order),
+        'step-c': trace('c', order),
+      },
+    })
+    expect(order).toEqual(['a', 'b', 'c'])
+    expect(result.outcome).toBe('ok')
+    expect(result.completedNodeIds).toEqual(['a', 'b', 'c'])
+  })
+
+  it('routes through a branch executor to the edge it returns', async () => {
+    const order: string[] = []
+    // picks outputs['true'] when flag is set, else outputs['false']
+    const wf = makeWorkflow(
+      [node('start', 'start'), node('cond', 'condition'), node('yes', 'yay'), node('no', 'nay')],
+      [edge('start', 'cond'), edge('cond', 'yes', 'true'), edge('cond', 'no', 'false')],
+    )
+    const result = await runWorkflow(wf, {
+      variables: { flag: true },
+      executors: {
+        start: trace('start', order),
+        condition: async (_data, ctx) => {
+          order.push('cond')
+          return (ctx.variables['flag'] ? ctx.outputs!['true'] : ctx.outputs!['false']) ?? null
+        },
+        yay: trace('yes', order),
+        nay: trace('no', order),
+      },
+    })
+    expect(order).toEqual(['start', 'cond', 'yes'])
+    expect(result.completedNodeIds).toEqual(['start', 'cond', 'yes'])
+    expect(result.outcome).toBe('ok')
+  })
+
+  it('cancels via an aborted signal', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const wf = makeWorkflow([node('a', 'step-a')], [])
+    const result = await runWorkflow(wf, {
+      signal: controller.signal,
+      executors: { 'step-a': trace('a', []) },
+    })
+    expect(result.outcome).toBe('cancelled')
+    expect(result.completedNodeIds).toEqual([])
+  })
+
+  it('treats an executor throwing AbortError as cancelled', async () => {
+    const controller = new AbortController()
+    const wf = makeWorkflow([node('a', 'boom')], [])
+    const result = await runWorkflow(wf, {
+      // signal not yet aborted; the executor itself throws AbortError.
+      signal: controller.signal,
+      executors: {
+        boom: async () => {
+          controller.abort()
+          throw new DOMException('Aborted', 'AbortError')
+        },
+      },
+    })
+    expect(result.outcome).toBe('cancelled')
+    expect(result.completedNodeIds).toEqual([])
+  })
+
+  it('a missing executor marks the run as failed', async () => {
+    const wf = makeWorkflow([node('a', 'not-registered')], [])
+    const steps: string[] = []
+    const result = await runWorkflow(wf, {
+      onStep: (_k, _id, text) => steps.push(text),
+    })
+    expect(result.outcome).toBe('failed')
+    expect(result.completedNodeIds).toEqual([])
+    expect(steps.some((s) => s.includes('没有找到块执行器'))).toBe(true)
+  })
+
+  it('dispatches by data.blockId and reads params from data.values (editor shape)', async () => {
+    // Reproduces the saved-graph shape where `label` is the localized display
+    // name (e.g. "手动运行") and user params live under data.values. The engine
+    // must resolve the executor via blockId and hand the executor the values bag.
+    const seen: Array<{ id: string; url?: unknown }> = []
+    const wf = makeWorkflow(
+      [
+        {
+          id: 'trigger',
+          label: '手动运行',
+          position: { x: 0, y: 0 },
+          data: { blockId: 'manual', values: {} },
+        },
+        {
+          id: 'open',
+          label: 'open-url',
+          position: { x: 0, y: 0 },
+          data: { blockId: 'open-url', values: { url: 'https://github.com/pulls/review-requested' } },
+        },
+      ],
+      [edge('trigger', 'open')],
+    )
+    const result = await runWorkflow(wf, {
+      executors: {
+        manual: async () => null,
+        'open-url': async (data) => {
+          seen.push({ id: 'open-url', url: data['url'] })
+          return null
+        },
+      },
+    })
+    expect(result.outcome).toBe('ok')
+    expect(result.completedNodeIds).toEqual(['trigger', 'open'])
+    expect(seen).toEqual([{ id: 'open-url', url: 'https://github.com/pulls/review-requested' }])
+  })
+
+  it('guards against dead loops once MAX_STEPS is exceeded', async () => {
+    const order: string[] = []
+    const wf = makeWorkflow([node('a', 'walk'), node('b', 'walk')], [edge('a', 'b'), edge('b', 'a')])
+    const steps: string[] = []
+    const result = await runWorkflow(wf, {
+      onStep: (_k, _id, text) => steps.push(text),
+      executors: { walk: trace('x', order) },
+    })
+    expect(result.outcome).toBe('failed')
+    expect(result.completedNodeIds.length).toBeGreaterThan(1000)
+    expect(steps.some((s) => s.includes('死循环'))).toBe(true)
+  })
+})
+
+describe('interpolate', () => {
+  it('resolves plain and nested variable tokens', () => {
+    expect(interpolate('hi {{name}}', { name: 'ralf' })).toBe('hi ralf')
+    expect(interpolate('{{user.email}}', { user: { email: 'a@b.c' } })).toBe('a@b.c')
+  })
+
+  it('resolves the special refData key (and its nested keys)', () => {
+    expect(interpolate('row {{refData}}', {}, { id: 7 })).toBe('row [object Object]')
+    expect(interpolate('row {{refData.id}}', {}, { id: 7 })).toBe('row 7')
+  })
+
+  it('preserves unmatched placeholders unchanged', () => {
+    expect(interpolate('{{missing}} and {{a.b}}', { a: {} })).toBe('{{missing}} and {{a.b}}')
+  })
+
+  it('stringifies function values', () => {
+    const fn = () => 42
+    expect(interpolate('{{fn}}', { fn })).toContain('=> 42')
+  })
+})

--- a/tests/workflow-executors.spec.ts
+++ b/tests/workflow-executors.spec.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { elementExists, execOnActiveTab } from '../src/background/driver'
+import {
+  EXECUTORS,
+  type WorkflowExecCtx,
+} from '../src/background/workflow-engine/executors'
+import type { OpResult } from '../src/lib/ops'
+
+/**
+ * The driver module is imported for real except `execOnActiveTab`, which we
+ * replace so executors never touch the real kernel. Every other driver export
+ * (`newTab`, `switchTab`, `closeActiveTab`) keeps its own chrome-backed logic,
+ * which is stubbed via the global `chrome` mock below.
+ */
+vi.mock('../src/background/driver', async (importActual) => {
+  const actual = await importActual<typeof import('../src/background/driver')>()
+  return {
+    ...actual,
+    execOnActiveTab: vi.fn(),
+    // elementExists reads the page via driver-internal execOnActiveTab, which the
+    // module mock above cannot intercept; stub it so branch executors are testable.
+    elementExists: vi.fn(async () => 1),
+  }
+})
+
+const opResult: OpResult = {
+  ok: true,
+  found: true,
+  frameUrl: 'https://example.com/',
+  isTopFrame: true,
+}
+
+/**
+ * In-memory `chrome` double covering every API the browser-class executors
+ * reach: tabs query/update/create/reload/remove/captureVisibleTab and
+ * scripting.executeScript.
+ */
+function makeChromeMock() {
+  const tab = {
+    id: 1,
+    windowId: 1,
+    url: 'https://example.com/',
+    title: 'Example',
+    active: true,
+  } as unknown as chrome.tabs.Tab
+  const query = vi.fn(async () => [tab])
+  const update = vi.fn(async () => tab)
+  const create = vi.fn(async () => tab)
+  const reload = vi.fn(async () => {})
+  const remove = vi.fn(async () => {})
+  const goBack = vi.fn(async () => {})
+  const goForward = vi.fn(async () => {})
+  const captureVisibleTab = vi.fn(async () => 'data:image/png;base64,ZZZ')
+  const executeScript = vi.fn(async (_details: { target: { tabId: number }; args?: unknown[] }) => [
+    { result: 'hello text' },
+  ])
+  return {
+    chrome: {
+      tabs: { query, update, create, reload, remove, goBack, goForward, captureVisibleTab },
+      scripting: { executeScript },
+    },
+    refs: { query, update, create, reload, remove, goBack, goForward, captureVisibleTab, executeScript, tab },
+  }
+}
+
+function makeCtx() {
+  const emit = vi.fn((_kind: 'status' | 'result' | 'error' | 'info', _text: string) => {})
+  const ctx: WorkflowExecCtx = {
+    variables: {},
+    refData: undefined,
+    signal: new AbortController().signal,
+    emit: emit as unknown as WorkflowExecCtx['emit'],
+  }
+  return { ctx, emit }
+}
+
+describe('workflow executors (browser class)', () => {
+  let chromeRefs: ReturnType<typeof makeChromeMock>['refs']
+  let driverMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    const mock = makeChromeMock()
+    chromeRefs = mock.refs
+    vi.stubGlobal('chrome', mock.chrome)
+    driverMock = vi.mocked(execOnActiveTab)
+    driverMock.mockReset()
+    driverMock.mockResolvedValue(opResult)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('click resolves the css selector and runs a click op', async () => {
+    const { ctx } = makeCtx()
+    await EXECUTORS['click']!({ cssSelector: '#btn' }, ctx)
+
+    expect(driverMock).toHaveBeenCalledTimes(1)
+    const [op] = driverMock.mock.calls[0]!
+    expect(op.action).toBe('click')
+    expect(op.target?.primary).toEqual({ how: 'css', value: '#btn' })
+  })
+
+  it('fill forwards its value into the op', async () => {
+    const { ctx } = makeCtx()
+    await EXECUTORS['fill']!({ cssSelector: '#in', value: 'hi' }, ctx)
+
+    const [op] = driverMock.mock.calls[0]!
+    expect(op.action).toBe('fill')
+    expect(op.target?.primary.value).toBe('#in')
+    expect(op.value).toBe('hi')
+  })
+
+  it('press-key emits a status before running the op', async () => {
+    const { ctx, emit } = makeCtx()
+    await EXECUTORS['press-key']!({ key: 'Enter' }, ctx)
+
+    expect(emit).toHaveBeenCalledWith('status', expect.stringContaining('Enter'))
+    const [op] = driverMock.mock.calls[0]!
+    expect(op.action).toBe('press_key')
+    expect(op.value).toBe('Enter')
+  })
+
+  it('scroll builds the right scroll spec for a mode', async () => {
+    const { ctx } = makeCtx()
+    await EXECUTORS['scroll']!({ cssSelector: '#footer', mode: 'bottom' }, ctx)
+
+    const [op] = driverMock.mock.calls[0]!
+    expect(op.action).toBe('scroll')
+    expect(op.scroll).toEqual({ mode: 'bottom', smooth: false })
+    expect(op.target?.primary.value).toBe('#footer')
+  })
+
+  it('open-url navigates only for http(s) addresses', async () => {
+    const { ctx } = makeCtx()
+    await EXECUTORS['open-url']!({ url: 'https://example.com/path' }, ctx)
+    expect(chromeRefs.update).toHaveBeenCalledWith(1, { url: 'https://example.com/path' })
+
+    chromeRefs.update.mockClear()
+    const { ctx: ctx2, emit } = makeCtx()
+    await EXECUTORS['open-url']!({ url: 'file:///C:/x.html' }, ctx2)
+    expect(chromeRefs.update).not.toHaveBeenCalled()
+    expect(emit).toHaveBeenCalledWith('error', expect.stringContaining('http'))
+  })
+
+  it('take-screenshot stores its data url in variables.lastScreenshot', async () => {
+    const { ctx, emit } = makeCtx()
+    chromeRefs.captureVisibleTab.mockResolvedValue('data:image/png;base64,XYZ')
+    await EXECUTORS['take-screenshot']!({}, ctx)
+
+    expect(chromeRefs.captureVisibleTab).toHaveBeenCalled()
+    expect(ctx.variables['lastScreenshot']).toBe('data:image/png;base64,XYZ')
+    expect(emit).toHaveBeenCalledWith('result', '已截图')
+  })
+
+  it('get-text injects a script and stores variables.lastText', async () => {
+    const { ctx } = makeCtx()
+    await EXECUTORS['get-text']!({ cssSelector: '.title' }, ctx)
+
+    expect(chromeRefs.executeScript).toHaveBeenCalledTimes(1)
+    const [details] = chromeRefs.executeScript.mock.calls[0]!
+    expect(details.target.tabId).toBe(1)
+    expect(details.args).toEqual(['.title'])
+    expect(ctx.variables['lastText']).toBe('hello text')
+  })
+
+  it('placeholder blocks emit an unimplemented notice and continue', async () => {
+    const { ctx, emit } = makeCtx()
+    // loop-data / execute-workflow are engine-handled; their registry entries stay placeholders.
+    const next = await EXECUTORS['execute-workflow']!({}, ctx)
+    expect(next).toBeNull()
+    expect(emit).toHaveBeenCalledWith('info', expect.stringContaining('尚未实现'))
+  })
+
+  it('wait-for reports through the op result and driver', async () => {
+    const { ctx, emit } = makeCtx()
+    await EXECUTORS['wait-for']!({ cssSelector: '[data-ok]' }, ctx)
+
+    const [op] = driverMock.mock.calls[0]!
+    expect(op.action).toBe('wait_for')
+    expect(emit).toHaveBeenCalledWith('result', '元素已出现')
+  })
+
+  it('an aborted signal aborts the step immediately', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const { ctx } = makeCtx()
+    const { emit, ...rest } = ctx
+    const aborted: WorkflowExecCtx = { ...rest, signal: controller.signal, emit }
+
+    await expect(EXECUTORS['click']!({ cssSelector: '#x' }, aborted)).rejects.toMatchObject({
+      name: 'AbortError',
+      message: 'Aborted',
+    })
+    expect(driverMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('workflow executors (automa-aligned browser actions)', () => {
+  let driverMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    const mock = makeChromeMock()
+    vi.stubGlobal('chrome', mock.chrome)
+    driverMock = vi.mocked(execOnActiveTab)
+    driverMock.mockReset()
+    driverMock.mockResolvedValue(opResult)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('element-exists routes to the exists edge when the element is found', async () => {
+    const { ctx, emit } = makeCtx()
+    const branched = { ...ctx, outputs: { exists: 'Y', notExists: 'N' }, defaultNext: 'N' }
+    const next = await EXECUTORS['element-exists']!({ cssSelector: '.item' }, branched)
+
+    expect(elementExists).toHaveBeenCalledTimes(1)
+    expect(next).toBe('Y')
+    expect(emit).toHaveBeenCalledWith('result', expect.stringContaining('元素存在'))
+  })
+
+  it('attribute-value get stores the op result in the output variable', async () => {
+    driverMock.mockResolvedValue({ ...opResult, data: 'attr-val' })
+    const { ctx, emit } = makeCtx()
+    await EXECUTORS['attribute-value']!(
+      { op: 'get', cssSelector: '#a', attribute: 'href', variableName: 'href' },
+      ctx,
+    )
+    expect(ctx.variables['href']).toBe('attr-val')
+    expect(emit).toHaveBeenCalledWith('result', 'attr-val')
+  })
+
+  it('trigger-event forwards event name and detail through the op', async () => {
+    const { ctx } = makeCtx()
+    await EXECUTORS['trigger-event']!(
+      { cssSelector: '#btn', event: 'myevent', detail: '{"x":1}' },
+      ctx,
+    )
+    const [op] = driverMock.mock.calls[0]!
+    expect(op.action).toBe('trigger_event')
+    expect(op.attribute).toBe('myevent')
+    expect(op.value).toBe('{"x":1}')
+  })
+
+  it('go-back calls the driver back-navigation', async () => {
+    // go-back routes through the real `goBack` driver function, not execOnActiveTab.
+    const { ctx, emit } = makeCtx()
+    await EXECUTORS['go-back']!({}, ctx)
+    expect(emit).toHaveBeenCalledWith('result', '已后退')
+  })
+
+  it('create-element injects the html through the op', async () => {
+    const { ctx } = makeCtx()
+    await EXECUTORS['create-element']!({ html: '<div>x</div>' }, ctx)
+    const [op] = driverMock.mock.calls[0]!
+    expect(op.action).toBe('create_element')
+    expect(op.value).toBe('<div>x</div>')
+  })
+})

--- a/tests/workflow-from-history.spec.ts
+++ b/tests/workflow-from-history.spec.ts
@@ -1,0 +1,199 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+beforeAll(() => {
+  vi.stubGlobal('chrome', {
+    storage: {
+      local: {
+        get: async () => ({}),
+        set: async () => {},
+        remove: async () => {},
+      },
+    },
+  })
+})
+
+import { workflowFromHistory } from '../src/lib/storage'
+import type { HistoryEntry } from '../src/lib/types'
+
+type Args = Record<string, unknown>
+
+let seq = 0
+function entry(action: string, args?: Args): HistoryEntry {
+  seq += 1
+  return {
+    id: `e-${seq}`,
+    at: seq,
+    conversationId: 'conv-1',
+    action,
+    summary: action,
+    approved: true,
+    ok: true,
+    ...(args ? { args } : {}),
+  }
+}
+
+/** Returns the `data.values` of all action nodes (skips the trigger node). */
+const nodesValues = (entries: HistoryEntry[], name = 'wf') =>
+  (workflowFromHistory(entries, name)?.drawflow.nodes ?? [])
+    .filter((n) => n.data.blockId !== 'manual')
+    .map((n) => n.data.values)
+
+describe('selectorFromArgs target synthesis', () => {
+  it("how:'css' keeps the trimmed selector", () => {
+    const values = nodesValues([entry('click', { target: { primary: { how: 'css', value: ' .btn ' } } })])
+    expect(values).toEqual([{ cssSelector: '.btn' }])
+  })
+
+  it("how:'id' yields a #id selector", () => {
+    const values = nodesValues([entry('click', { target: { primary: { how: 'id', value: 'submit' } } })])
+    expect(values).toEqual([{ cssSelector: '#submit' }])
+  })
+
+  it("how:'name' yields a [name=...] selector", () => {
+    const values = nodesValues([entry('click', { target: { primary: { how: 'name', value: 'q' } } })])
+    expect(values).toEqual([{ cssSelector: '[name="q"]' }])
+  })
+
+  it("how:'testid' yields a [data-testid=...] selector", () => {
+    const values = nodesValues([entry('click', { target: { primary: { how: 'testid', value: 'x' } } })])
+    expect(values).toEqual([{ cssSelector: '[data-testid="x"]' }])
+  })
+})
+
+describe('args fall through to mapped block values', () => {
+  it('fill combines a synthesized selector with a literal value', () => {
+    const wf = workflowFromHistory(
+      [entry('fill', { target: { primary: { how: 'id', value: 'n' } }, value: 'abc' })],
+      'wf',
+    )
+    // 1 trigger + 1 action
+    expect(wf?.drawflow.nodes).toHaveLength(2)
+    expect(wf?.drawflow.nodes[1]!.data.values).toEqual({ cssSelector: '#n', value: 'abc' })
+  })
+
+  it('press_key carries through the key', () => {
+    expect(nodesValues([entry('press_key', { key: 'Enter' })])).toEqual([{ key: 'Enter' }])
+  })
+
+  it('scroll keeps mode/y instead of hard-coding into_view', () => {
+    const values = nodesValues([
+      entry('scroll', { mode: 'by', y: 100, target: { primary: { how: 'css', value: '.x' } } }),
+    ])
+    expect(values).toEqual([{ mode: 'by', cssSelector: '.x', y: 100 }])
+  })
+
+  it('wait_for carries the timeout', () => {
+    const values = nodesValues([
+      entry('wait_for', { target: { primary: { how: 'css', value: '.a' } }, timeout: 3000 }),
+    ])
+    expect(values).toEqual([{ cssSelector: '.a', timeout: 3000 }])
+  })
+
+  it('tab_switch carries the index', () => {
+    expect(nodesValues([entry('tab_switch', { index: 2 })])).toEqual([{ index: 2 }])
+  })
+
+  it('open_url carries the url', () => {
+    expect(nodesValues([entry('open_url', { url: 'https://e.com' })])).toEqual([
+      { url: 'https://e.com' },
+    ])
+  })
+})
+
+describe('trigger node', () => {
+  it('prepends a manual trigger node connected to the first action', () => {
+    const wf = workflowFromHistory(
+      [entry('click', { target: { primary: { how: 'css', value: '.btn' } } })],
+      'wf',
+    )
+    expect(wf).not.toBeNull()
+    // trigger + 1 action
+    expect(wf!.drawflow.nodes).toHaveLength(2)
+    expect(wf!.drawflow.edges).toHaveLength(1)
+    expect(wf!.drawflow.nodes[0]!.data.blockId).toBe('manual')
+    expect(wf!.drawflow.edges[0]!.source).toBe(wf!.drawflow.nodes[0]!.id)
+    expect(wf!.drawflow.edges[0]!.target).toBe(wf!.drawflow.nodes[1]!.id)
+  })
+})
+
+describe('unmapped actions', () => {
+  it('returns null when nothing is mappable', () => {
+    expect(workflowFromHistory([entry('read_current_page', {})], 'wf')).toBeNull()
+  })
+
+  it('skips unmapped actions and links the mapped ones in order', () => {
+    const wf = workflowFromHistory(
+      [
+        entry('open_url', { url: 'https://e.com' }),
+        entry('read_current_page', {}),
+        entry('click', { target: { primary: { how: 'testid', value: 'x' } } }),
+      ],
+      'wf',
+    )
+    expect(wf).not.toBeNull()
+    // trigger + open_url + click = 3
+    expect(wf!.drawflow.nodes).toHaveLength(3)
+    // trigger→open_url + open_url→click = 2
+    expect(wf!.drawflow.edges).toHaveLength(2)
+    expect(
+      wf!.drawflow.nodes
+        .filter((n) => n.data.blockId !== 'manual')
+        .map((n) => n.data.values),
+    ).toEqual([{ url: 'https://e.com' }, { cssSelector: '[data-testid="x"]' }])
+    // First edge: trigger → first action
+    expect(wf!.drawflow.edges[0]!.source).toBe(wf!.drawflow.nodes[0]!.id)
+    expect(wf!.drawflow.edges[0]!.target).toBe(wf!.drawflow.nodes[1]!.id)
+    // Second edge: first action → second action
+    expect(wf!.drawflow.edges[1]!.source).toBe(wf!.drawflow.nodes[1]!.id)
+    expect(wf!.drawflow.edges[1]!.target).toBe(wf!.drawflow.nodes[2]!.id)
+  })
+})
+
+describe('duplicate collapsing', () => {
+  it('collapses consecutive open_url calls to the same URL into one block', () => {
+    // Reproduces the saved workflow where the model opened the same URL twice
+    // (e.g. once to navigate and again after a re-read). A replayable workflow
+    // only needs the navigation once.
+    const wf = workflowFromHistory(
+      [
+        entry('open_url', { url: 'https://github.com/pulls/review-requested' }),
+        entry('read_current_page', {}),
+        entry('open_url', { url: 'https://github.com/pulls/review-requested' }),
+      ],
+      'prs',
+    )
+    expect(wf).not.toBeNull()
+    const actionNodes = wf!.drawflow.nodes.filter((n) => n.data.blockId !== 'manual')
+    expect(actionNodes).toHaveLength(1)
+    expect(actionNodes[0]!.data.values).toEqual({
+      url: 'https://github.com/pulls/review-requested',
+    })
+  })
+
+  it('keeps two open_url calls when the URLs differ', () => {
+    const wf = workflowFromHistory(
+      [
+        entry('open_url', { url: 'https://a.com' }),
+        entry('open_url', { url: 'https://b.com' }),
+      ],
+      'wf',
+    )
+    const actionNodes = wf!.drawflow.nodes.filter((n) => n.data.blockId !== 'manual')
+    expect(actionNodes).toHaveLength(2)
+  })
+
+  it('collapses two clicks on the same selector but keeps clicks on different ones', () => {
+    const wf = workflowFromHistory(
+      [
+        entry('click', { target: { primary: { how: 'css', value: '.a' } } }),
+        entry('click', { target: { primary: { how: 'css', value: '.a' } } }),
+        entry('click', { target: { primary: { how: 'css', value: '.b' } } }),
+      ],
+      'wf',
+    )
+    const selectors = wf!.drawflow.nodes
+      .filter((n) => n.data.blockId !== 'manual')
+      .map((n) => n.data.values.cssSelector)
+    expect(selectors).toEqual(['.a', '.b'])
+  })
+})

--- a/tests/workflow-phase4.spec.ts
+++ b/tests/workflow-phase4.spec.ts
@@ -1,0 +1,457 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runWorkflow } from '../src/background/workflow-engine/engine'
+import {
+  EXECUTORS,
+  type WorkflowExecCtx,
+} from '../src/background/workflow-engine/executors'
+import { streamCompletion } from '../src/lib/llm'
+import { getSettings } from '../src/lib/storage'
+import { getWorkflow } from '../src/lib/workflow/storage'
+import type { Workflow, WorkflowEdge, WorkflowNode } from '../src/lib/workflow/types'
+
+/**
+ * Phase 4: non-browser executors plus the engine's `loop-data` /
+ * `execute-workflow` special handling. Storage / llm are mocked so the ai-prompt
+ * and execute-workflow blocks never touch chrome or a real model.
+ */
+
+vi.mock('../src/lib/workflow/storage', async (importActual) => {
+  const actual = await importActual<typeof import('../src/lib/workflow/storage')>()
+  return { ...actual, getWorkflow: vi.fn() }
+})
+
+vi.mock('../src/lib/llm', async (importActual) => {
+  const actual = await importActual<typeof import('../src/lib/llm')>()
+  return { ...actual, streamCompletion: vi.fn() }
+})
+
+vi.mock('../src/lib/storage', async (importActual) => {
+  const actual = await importActual<typeof import('../src/lib/storage')>()
+  return { ...actual, getSettings: vi.fn() }
+})
+
+/** Build a minimal Workflow from nodes + edges. */
+function makeWorkflow(nodes: WorkflowNode[], edges: WorkflowEdge[]): Workflow {
+  return {
+    id: 'wf',
+    name: 'wf',
+    createdAt: 0,
+    updatedAt: 0,
+    drawflow: { nodes, edges },
+    settings: {
+      saveLog: false,
+      debugMode: false,
+      notification: false,
+      reuseLastState: false,
+    },
+  }
+}
+
+const node = (id: string, label: string, data: Record<string, unknown> = {}): WorkflowNode => ({
+  id,
+  label,
+  position: { x: 0, y: 0 },
+  data,
+})
+
+const edge = (source: string, target: string, handle?: string): WorkflowEdge => ({
+  id: `${source}->${target}`,
+  source,
+  target,
+  ...(handle ? { sourceHandle: handle } : {}),
+})
+
+function makeCtx() {
+  const emit = vi.fn()
+  const ctx: WorkflowExecCtx = {
+    variables: {},
+    refData: undefined,
+    signal: new AbortController().signal,
+    emit: emit as unknown as WorkflowExecCtx['emit'],
+  }
+  return { ctx, emit }
+}
+
+describe('workflow phase 4 — data & control-flow blocks via runWorkflow', () => {
+  beforeEach(() => {
+    vi.mocked(getWorkflow).mockReset()
+    vi.mocked(streamCompletion).mockReset()
+    vi.mocked(getSettings).mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('set/get/insert/export run end-to-end sharing the variables object', async () => {
+    let captured: Record<string, unknown> = {}
+    const wf = makeWorkflow(
+      [
+        node('t', 'manual'),
+        node('set', 'set-variable', { variableName: 'name', value: 'world' }),
+        node('get', 'get-variable', { variableName: 'name' }),
+        node('ins', 'insert-data', { data: '[{"a":1,"b":"x"},{"a":2,"b":"y,z"}]' }),
+        node('exp', 'export-data', { format: 'csv' }),
+        node('probe', 'probe'),
+      ],
+      [
+        edge('t', 'set'),
+        edge('set', 'get'),
+        edge('get', 'ins'),
+        edge('ins', 'exp'),
+        edge('exp', 'probe'),
+      ],
+    )
+    const result = await runWorkflow(wf, {
+      executors: {
+        ...EXECUTORS,
+        probe: async (_d, ctx) => {
+          captured = { ...ctx.variables }
+          return null
+        },
+      },
+    })
+
+    expect(result.outcome).toBe('ok')
+    expect(captured['name']).toBe('world')
+    expect(captured['lastValue']).toBe('world')
+    expect(captured['dataTable']).toEqual([
+      { a: 1, b: 'x' },
+      { a: 2, b: 'y,z' },
+    ])
+    // csv: header from the first row's keys; comma-bearing cells are quoted.
+    expect(captured['lastExport']).toBe('a,b\n1,x\n2,"y,z"')
+  })
+
+  it('javascript-code stores its return value in lastResult', async () => {
+    let captured: unknown = null
+    const wf = makeWorkflow(
+      [node('t', 'manual'), node('js', 'javascript-code', { code: 'return 42' }), node('p', 'probe')],
+      [edge('t', 'js'), edge('js', 'p')],
+    )
+    const result = await runWorkflow(wf, {
+      executors: {
+        ...EXECUTORS,
+        probe: async (_d, ctx) => {
+          captured = ctx.variables['lastResult']
+          return null
+        },
+      },
+    })
+    expect(result.outcome).toBe('ok')
+    expect(captured).toBe(42)
+  })
+
+  it('trigger blocks are pass-through no-ops that still route onward', async () => {
+    let ran = false
+    const wf = makeWorkflow([node('t', 'manual'), node('p', 'probe')], [edge('t', 'p')])
+    const result = await runWorkflow(wf, {
+      executors: {
+        ...EXECUTORS,
+        probe: async () => {
+          ran = true
+          return null
+        },
+      },
+    })
+    expect(result.outcome).toBe('ok')
+    expect(ran).toBe(true)
+  })
+
+  it('condition routes to the true edge when the expression is truthy', async () => {
+    const calls: string[] = []
+    const wf = makeWorkflow(
+      [node('t', 'manual'), node('c', 'condition', { code: '1+1===2' }), node('b', 'b'), node('n', 'n')],
+      [edge('t', 'c'), edge('c', 'b', 'true'), edge('c', 'n', 'false')],
+    )
+    await runWorkflow(wf, {
+      executors: {
+        ...EXECUTORS,
+        b: async () => {
+          calls.push('b')
+          return null
+        },
+        n: async () => {
+          calls.push('n')
+          return null
+        },
+      },
+    })
+    expect(calls).toEqual(['b'])
+  })
+
+  it('condition routes to the false edge when the expression is falsy', async () => {
+    const calls: string[] = []
+    const wf = makeWorkflow(
+      [node('t', 'manual'), node('c', 'condition', { code: '1===2' }), node('b', 'b'), node('n', 'n')],
+      [edge('t', 'c'), edge('c', 'b', 'true'), edge('c', 'n', 'false')],
+    )
+    await runWorkflow(wf, {
+      executors: {
+        ...EXECUTORS,
+        b: async () => {
+          calls.push('b')
+          return null
+        },
+        n: async () => {
+          calls.push('n')
+          return null
+        },
+      },
+    })
+    expect(calls).toEqual(['n'])
+  })
+})
+
+describe('workflow phase 4 — loop-data', () => {
+  beforeEach(() => {
+    vi.mocked(getWorkflow).mockReset()
+  })
+  afterEach(() => vi.clearAllMocks())
+
+  it('runs its body once per item, exposing loopIndex / loopItem', async () => {
+    const seen: Array<{ index: unknown; item: unknown }> = []
+    const wf = makeWorkflow(
+      [
+        node('t', 'manual'),
+        node('loop', 'loop-data', { data: '[10,20,30]' }),
+        node('body', 'body'),
+        node('exit', 'exit'),
+      ],
+      [edge('t', 'loop'), edge('loop', 'body'), edge('body', 'exit')],
+    )
+    const result = await runWorkflow(wf, {
+      executors: {
+        ...EXECUTORS,
+        body: async (_d, ctx) => {
+          seen.push({ index: ctx.variables['loopIndex'], item: ctx.variables['loopItem'] })
+          return null
+        },
+        exit: async () => null,
+      },
+    })
+    expect(result.outcome).toBe('ok')
+    expect(seen).toEqual([
+      { index: 0, item: 10 },
+      { index: 1, item: 20 },
+      { index: 2, item: 30 },
+    ])
+  })
+
+  it('repeat-task runs its body a fixed number of times', async () => {
+    const seen: unknown[] = []
+    const wf = makeWorkflow(
+      [
+        node('t', 'manual'),
+        node('loop', 'repeat-task', { count: 3 }),
+        node('body', 'body'),
+        node('exit', 'exit'),
+      ],
+      [edge('t', 'loop'), edge('loop', 'body'), edge('body', 'exit')],
+    )
+    const result = await runWorkflow(wf, {
+      executors: {
+        ...EXECUTORS,
+        body: async (_d, ctx) => {
+          seen.push(ctx.variables['loopIndex'])
+          return null
+        },
+        exit: async () => null,
+      },
+    })
+    expect(result.outcome).toBe('ok')
+    expect(seen).toEqual([0, 1, 2])
+  })
+
+  it('while-loop runs while its condition holds and terminates when it flips false', async () => {
+    const seen: unknown[] = []
+    const wf = makeWorkflow(
+      [
+        node('t', 'manual'),
+        node('loop', 'while-loop', { code: 'vars.counter < 3' }),
+        node('body', 'body'),
+        node('exit', 'exit'),
+      ],
+      [edge('t', 'loop'), edge('loop', 'body'), edge('body', 'exit')],
+    )
+    const result = await runWorkflow(wf, {
+      variables: { counter: 0 },
+      executors: {
+        ...EXECUTORS,
+        body: async (_d, ctx) => {
+          seen.push(ctx.variables['loopIndex'])
+          ctx.variables['counter'] = Number(ctx.variables['counter']) + 1
+          return null
+        },
+        exit: async () => null,
+      },
+    })
+    expect(result.outcome).toBe('ok')
+    expect(seen).toEqual([0, 1, 2])
+  })
+
+  it('loop-elements iterates the count from the loopElementCounter hook', async () => {
+    const seen: unknown[] = []
+    const wf = makeWorkflow(
+      [
+        node('t', 'manual'),
+        node('loop', 'loop-elements', { cssSelector: '.item' }),
+        node('body', 'body'),
+        node('exit', 'exit'),
+      ],
+      [edge('t', 'loop'), edge('loop', 'body'), edge('body', 'exit')],
+    )
+    const result = await runWorkflow(wf, {
+      loopElementCounter: async (selector) => {
+        expect(selector).toBe('.item')
+        return 3
+      },
+      executors: {
+        ...EXECUTORS,
+        body: async (_d, ctx) => {
+          seen.push(ctx.variables['loopIndex'])
+          return null
+        },
+        exit: async () => null,
+      },
+    })
+    expect(result.outcome).toBe('ok')
+    expect(seen).toEqual([0, 1, 2])
+  })
+})
+
+describe('workflow phase 4 — execute-workflow', () => {
+  beforeEach(() => {
+    vi.mocked(getWorkflow).mockReset()
+  })
+  afterEach(() => vi.clearAllMocks())
+
+  it('runs a referenced sub-workflow then continues on the default edge', async () => {
+    const sub = makeWorkflow([node('s', 'sub-body')], [])
+    vi.mocked(getWorkflow).mockResolvedValue(sub)
+
+    const order: string[] = []
+    const wf = makeWorkflow(
+      [
+        node('t', 'manual'),
+        node('ex', 'execute-workflow', { workflowId: 'sub-1' }),
+        node('after', 'after-node'),
+      ],
+      [edge('t', 'ex'), edge('ex', 'after')],
+    )
+    const result = await runWorkflow(wf, {
+      executors: {
+        ...EXECUTORS,
+        'sub-body': async () => {
+          order.push('sub-body')
+          return null
+        },
+        'after-node': async () => {
+          order.push('after')
+          return null
+        },
+      },
+    })
+    expect(result.outcome).toBe('ok')
+    expect(order).toEqual(['sub-body', 'after'])
+  })
+
+  it('guards a→a self-loops via parentWorkflowIds', async () => {
+    const wf = makeWorkflow(
+      [
+        node('t', 'manual'),
+        node('ex', 'execute-workflow', { workflowId: 'wf-self' }),
+        node('after', 'after'),
+      ],
+      [edge('t', 'ex'), edge('ex', 'after')],
+    )
+    const steps: string[] = []
+    const result = await runWorkflow(wf, {
+      parentWorkflowIds: new Set(['wf-self']),
+      onStep: (_k, _id, text) => steps.push(text),
+      executors: { ...EXECUTORS, after: async () => null },
+    })
+    expect(result.outcome).toBe('ok')
+    expect(vi.mocked(getWorkflow)).not.toHaveBeenCalled()
+    expect(steps.some((s) => s.includes('自循环'))).toBe(true)
+  })
+})
+
+describe('workflow phase 4 — integration executors', () => {
+  beforeEach(() => {
+    vi.mocked(getSettings).mockReset()
+    vi.mocked(streamCompletion).mockReset()
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('delay resolves after a short wait and emits a status', async () => {
+    const { ctx, emit } = makeCtx()
+    await EXECUTORS['delay']!({ ms: '5' }, ctx)
+    expect(emit).toHaveBeenCalledWith('status', expect.stringContaining('延时'))
+  })
+
+  it('webhook posts the parsed body and emits result', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      text: async () => 'accepted',
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { ctx, emit } = makeCtx()
+    await EXECUTORS['webhook']!({ url: 'https://example.com/hook', body: '{"x":1}' }, ctx)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('https://example.com/hook')
+    expect(JSON.parse(init.body as string)).toEqual({ x: 1 })
+    expect(emit).toHaveBeenCalledWith('result', 'POST 200 accepted')
+  })
+
+  it('notification creates a chrome notification and emits result', async () => {
+    const create = vi.fn(async () => 'notif-id')
+    vi.stubGlobal('chrome', { notifications: { create } })
+    const { ctx, emit } = makeCtx()
+    await EXECUTORS['notification']!({ title: 'Hi', message: 'There' }, ctx)
+
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({ title: 'Hi', message: 'There' }))
+    expect(emit).toHaveBeenCalledWith('result', '已通知')
+  })
+
+  it('ai-prompt calls the configured provider and stores lastAIResponse', async () => {
+    vi.mocked(getSettings).mockResolvedValue({
+      providers: [
+        { id: 'p1', label: 'p1', presetId: 'custom', baseUrl: 'https://x', apiKey: 'key', model: 'm' },
+      ],
+      activeProviderId: 'p1',
+    } as unknown as Awaited<ReturnType<typeof getSettings>>)
+    vi.mocked(streamCompletion).mockResolvedValue({
+      content: 'hello ai',
+      toolCalls: [],
+      finishReason: 'stop',
+      usage: null,
+    } as Awaited<ReturnType<typeof streamCompletion>>)
+
+    const { ctx, emit } = makeCtx()
+    await EXECUTORS['ai-prompt']!({ prompt: 'hi' }, ctx)
+
+    expect(ctx.variables['lastAIResponse']).toBe('hello ai')
+    expect(emit).toHaveBeenCalledWith('result', 'hello ai')
+  })
+
+  it('ai-prompt emits an error when no provider is configured', async () => {
+    vi.mocked(getSettings).mockResolvedValue({
+      providers: [],
+      activeProviderId: '',
+    } as unknown as Awaited<ReturnType<typeof getSettings>>)
+
+    const { ctx, emit } = makeCtx()
+    await EXECUTORS['ai-prompt']!({ prompt: 'hi' }, ctx)
+
+    expect(emit).toHaveBeenCalledWith('error', 'AI 块: 未配置模型给 provider')
+  })
+})

--- a/tests/workflow-scheduler.spec.ts
+++ b/tests/workflow-scheduler.spec.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ScheduledTask } from '../src/lib/scheduler-types'
+import {
+  rescheduleAll,
+  scheduleTask,
+  taskIdFromAlarmName,
+} from '../src/background/scheduler'
+
+/**
+ * Shared mutable task store, seeded via `setTasks`. Exposed through
+ * `vi.hoisted` so the `vi.mock` factory below can read it before the test body
+ * runs. The task-runner is stubbed so importing the scheduler does not pull in
+ * the agent/github/feishu machinery.
+ */
+const store = vi.hoisted(() => {
+  const tasks: unknown[] = []
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tasks: tasks as any[],
+    setTasks: (next: unknown[]) => {
+      tasks.splice(0, tasks.length, ...next)
+    },
+  }
+})
+
+vi.mock('../src/background/task-runner', () => ({
+  runTask: vi.fn(async () => ({ ok: true, skipped: false, summary: '' })),
+}))
+
+vi.mock('../src/lib/task-store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/lib/task-store')>()
+  return {
+    ...actual,
+    getTask: vi.fn(async (id: string) => store.tasks.find((t) => t.id === id)),
+    listTasks: vi.fn(async () => [...store.tasks]),
+  }
+})
+
+// A separate alarm double keeps the real implementations readable.
+const alarmsByName = new Map<string, { name: string; when?: number }>()
+const createdCalls: string[] = []
+const clearedCalls: string[] = []
+
+function makeTask(partial: Partial<ScheduledTask> & Pick<ScheduledTask, 'id'>): ScheduledTask {
+  return {
+    name: 'Task',
+    enabled: true,
+    schedule: { kind: 'interval', minutes: 60 },
+    kind: 'agent-prompt',
+    prompt: 'hello',
+    maxToolRounds: 25,
+    notifyFeishu: false,
+    createdAt: 0,
+    updatedAt: 0,
+    ...partial,
+  }
+}
+
+describe('workflow scheduler alarm prefixes', () => {
+  beforeEach(() => {
+    createdCalls.length = 0
+    clearedCalls.length = 0
+    alarmsByName.clear()
+    vi.stubGlobal('chrome', {
+      alarms: {
+        create: vi.fn(async (name: string, info?: { when?: number }) => {
+          alarmsByName.set(name, { name, ...(info ? { when: info.when } : {}) })
+          createdCalls.push(name)
+        }),
+        clear: vi.fn(async (name: string) => {
+          alarmsByName.delete(name)
+          clearedCalls.push(name)
+          return true
+        }),
+        getAll: vi.fn(async () => [...alarmsByName.values()]),
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('parses both task: and workflow: alarm prefixes', () => {
+    expect(taskIdFromAlarmName('workflow:abc')).toBe('abc')
+    expect(taskIdFromAlarmName('task:def')).toBe('def')
+    expect(taskIdFromAlarmName('other:ghi')).toBeNull()
+  })
+
+  it('schedules a workflow-kind task under the workflow: prefix', async () => {
+    store.setTasks([makeTask({ id: 'wf-task', kind: 'workflow', workflowId: 'wf-1' })])
+
+    await scheduleTask('wf-task')
+
+    expect(createdCalls).toEqual(['workflow:wf-task'])
+    expect(clearedCalls).toEqual([])
+  })
+
+  it('still schedules plain tasks under the task: prefix', async () => {
+    store.setTasks([makeTask({ id: 'plain' })])
+
+    await scheduleTask('plain')
+
+    expect(createdCalls).toEqual(['task:plain'])
+  })
+
+  it('rescheduleAll clears orphaned workflow alarms and arms known ones', async () => {
+    store.setTasks([makeTask({ id: 'wf-task', kind: 'workflow', workflowId: 'wf-1' })])
+    // A stale alarm from a now-deleted workflow task, and one from a plain task.
+    alarmsByName.set('workflow:gone', { name: 'workflow:gone' })
+    alarmsByName.set('task:gone', { name: 'task:gone' })
+
+    await rescheduleAll()
+
+    expect(clearedCalls).toEqual(expect.arrayContaining(['workflow:gone', 'task:gone']))
+    expect(alarmsByName.has('workflow:gone')).toBe(false)
+    expect(alarmsByName.has('task:gone')).toBe(false)
+    expect(createdCalls).toContain('workflow:wf-task')
+  })
+})

--- a/tests/workflow-storage.spec.ts
+++ b/tests/workflow-storage.spec.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  deleteWorkflow,
+  duplicateWorkflow,
+  getWorkflow,
+  listWorkflows,
+  saveWorkflow,
+} from '../src/lib/workflow/storage'
+import type { Workflow } from '../src/lib/workflow/types'
+import { validateWorkflow } from '../src/lib/workflow/validation'
+
+/**
+ * In-memory `chrome.storage.local` double. Only `get`/`set` are needed here
+ * (workflows never call `remove`), but the whole surface is stubbed so any
+ * accidental misuse fails loudly instead of silently.
+ */
+function makeChromeMock() {
+  const store = new Map<string, unknown>()
+  const local = {
+    get: vi.fn(async (keys: string | string[]) => {
+      const wanted = typeof keys === 'string' ? [keys] : keys
+      const out: Record<string, unknown> = {}
+      for (const key of wanted) {
+        if (store.has(key)) out[key] = store.get(key)
+      }
+      return out
+    }),
+    set: vi.fn(async (items: Record<string, unknown>) => {
+      for (const [key, value] of Object.entries(items)) store.set(key, value)
+    }),
+    remove: vi.fn(async (keys: string | string[]) => {
+      const wanted = typeof keys === 'string' ? [keys] : keys
+      for (const key of wanted) store.delete(key)
+      return Promise.resolve()
+    }),
+  }
+  return { store, storage: { local: { get: local.get, set: local.set, remove: local.remove } } }
+}
+
+function makeWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  const now = Date.now()
+  return {
+    id: 'wf-1',
+    name: 'Scrape leads',
+    description: 'Collect contact rows',
+    createdAt: now,
+    updatedAt: now,
+    drawflow: { nodes: [], edges: [] },
+    settings: {
+      saveLog: false,
+      debugMode: false,
+      notification: true,
+      reuseLastState: false,
+    },
+    ...overrides,
+  }
+}
+
+describe('workflow storage', () => {
+  let mocks: ReturnType<typeof makeChromeMock>
+
+  beforeEach(() => {
+    mocks = makeChromeMock()
+    vi.stubGlobal('chrome', mocks)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('returns saved workflows from list and get', async () => {
+    await saveWorkflow(makeWorkflow({ id: 'a', name: 'Alpha' }))
+
+    const list = await listWorkflows()
+    expect(list).toHaveLength(1)
+    expect(list[0]!.id).toBe('a')
+    expect(list[0]!.name).toBe('Alpha')
+
+    const got = await getWorkflow('a')
+    expect(got!.name).toBe('Alpha')
+    expect(got!.settings.notification).toBe(true)
+  })
+
+  it('returns an empty list when nothing is stored', async () => {
+    expect(await listWorkflows()).toEqual([])
+    expect(await getWorkflow('missing')).toBeUndefined()
+  })
+
+  it('sorts saved workflows by updatedAt descending', async () => {
+    const clock = vi.spyOn(Date, 'now').mockImplementation(() => 1000)
+    try {
+      await saveWorkflow(makeWorkflow({ id: 'a', name: 'A' }))
+      clock.mockImplementation(() => 2000)
+      await saveWorkflow(makeWorkflow({ id: 'b', name: 'B' }))
+      clock.mockImplementation(() => 3000)
+      // Touching A bumps it above B.
+      await saveWorkflow(makeWorkflow({ id: 'a', name: 'A v2' }))
+
+      const list = await listWorkflows()
+      expect(list.map((w) => w.id)).toEqual(['a', 'b'])
+      expect(list[0]!.updatedAt).toBe(3000)
+    } finally {
+      clock.mockRestore()
+    }
+  })
+
+  it('updates an existing workflow instead of duplicating it', async () => {
+    await saveWorkflow(makeWorkflow({ id: 'a', name: 'Old' }))
+    await saveWorkflow(makeWorkflow({ id: 'a', name: 'New' }))
+
+    const list = await listWorkflows()
+    expect(list).toHaveLength(1)
+    expect(list[0]!.name).toBe('New')
+  })
+
+  it('removes a workflow on delete', async () => {
+    await saveWorkflow(makeWorkflow({ id: 'a' }))
+    await saveWorkflow(makeWorkflow({ id: 'b' }))
+
+    await deleteWorkflow('a')
+
+    const list = await listWorkflows()
+    expect(list.map((w) => w.id)).toEqual(['b'])
+    expect(await getWorkflow('a')).toBeUndefined()
+  })
+
+  it('duplicates a workflow under a new id with the given name', async () => {
+    await saveWorkflow(
+      makeWorkflow({ id: 'a', name: 'Original', table: 'tbl-1' }),
+    )
+
+    const copy = await duplicateWorkflow('a', 'Renamed copy')
+
+    expect(copy).toBeDefined()
+    expect(copy!.id).not.toBe('a')
+    expect(copy!.name).toBe('Renamed copy')
+    expect(copy!.table).toBe('tbl-1')
+    // Both records survive; the duplicate is independent of the source.
+    const ids = new Set((await listWorkflows()).map((w) => w.id))
+    expect(ids).toEqual(new Set([copy!.id, 'a']))
+  })
+
+  it('duplicates with a "(copy)" suffix when no name is given', async () => {
+    await saveWorkflow(makeWorkflow({ id: 'a', name: 'Original' }))
+    const copy = await duplicateWorkflow('a')
+    expect(copy!.name).toBe('Original (copy)')
+  })
+
+  it('returns undefined when duplicating an unknown id', async () => {
+    expect(await duplicateWorkflow('nope')).toBeUndefined()
+  })
+})
+
+describe('validateWorkflow', () => {
+  it('accepts a well-formed workflow', () => {
+    const wf = makeWorkflow()
+    expect(validateWorkflow(wf)).toEqual([])
+  })
+
+  it('reports missing id and name', () => {
+    const problems = validateWorkflow(makeWorkflow({ id: '', name: '   ' }))
+    expect(problems.join(' | ')).toMatch(/id/)
+    expect(problems.join(' | ')).toMatch(/name/)
+  })
+
+  it('rejects a non-object payload', () => {
+    expect(validateWorkflow(null).length).toBeGreaterThan(0)
+    expect(validateWorkflow('nope').length).toBeGreaterThan(0)
+  })
+
+  it('flags non-array nodes and edges', () => {
+    const bad = makeWorkflow({
+      drawflow: { nodes: 'x' as unknown as [], edges: {} as unknown as [] },
+    })
+    const problems = validateWorkflow(bad).join(' | ')
+    expect(problems).toMatch(/nodes/)
+    expect(problems).toMatch(/edges/)
+  })
+
+  it('flags nodes missing a label or position', () => {
+    const bad = makeWorkflow({
+      drawflow: {
+        nodes: [
+          { id: 'n1', label: 'ok', position: { x: 0, y: 0 }, data: {} },
+          { id: 'n2', position: { x: 1, y: 1 }, data: {} } as never,
+          { id: 'n3', label: 'no pos', data: {} } as never,
+        ],
+        edges: [],
+      },
+    })
+    const problems = validateWorkflow(bad).join(' | ')
+    expect(problems).toMatch(/label/)
+    expect(problems).toMatch(/position/)
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@
 // only as long as some file in the same program pulls in Vitest's type
 // augmentation, which made this config's validity depend on unrelated includes.
 import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
 import react from '@vitejs/plugin-react'
 import { crx } from '@crxjs/vite-plugin'
 import manifest from './manifest.config'
@@ -14,6 +15,15 @@ export default defineConfig({
     // Extension pages are loaded from disk; readable output helps debugging.
     minify: false,
     sourcemap: true,
+    rollupOptions: {
+      // Extra extension page (the visual workflow editor) opened via
+      // chrome.runtime.getURL('src/workflow-editor/index.html'). The side panel
+      // is already wired through the manifest and handled by the crx plugin.
+      input: {
+        'workflow-editor': fileURLToPath(new URL('src/workflow-editor/index.html', import.meta.url)),
+        'offscreen': fileURLToPath(new URL('src/offscreen/index.html', import.meta.url)),
+      },
+    },
   },
   test: {
     environment: 'node',


### PR DESCRIPTION

The engine previously looked up block executors by WorkflowNode.label, which holds the localized display name, while the EXECUTORS map is keyed by English block ids. Saved workflows from the chat-generated path therefore failed immediately with a missing-executor error for the localized trigger label.

Changes:
- engine: resolve block id from data.blockId (falling back to label for legacy graphs) and pass data.values as the executor param bag so blocks read the same shape the editor persists
- storage: workflowFromHistory now labels the trigger node with the block id (manual) instead of the Chinese display name, collapses consecutive equivalent steps (the model occasionally re-issues the same open_url after a page re-read), and synthesizes selectors for tag+nth targets
- executors registry doc comment updated to match the dispatch contract
- tests: add a regression test for the saved-editor-shape dispatch and cases for duplicate-step collapsing