### PR TITLE
feat(page): click elements inside closed shadow DOM via CDP

### DIFF
--- a/src/background/agent.ts
+++ b/src/background/agent.ts
@@ -530,6 +530,7 @@ function summarizeSnapshot(snapshot: {
     checked?: boolean
     required?: boolean
     inViewport: boolean
+    target?: unknown
   }>
   forms: unknown
   scrollY: number
@@ -552,6 +553,10 @@ function summarizeSnapshot(snapshot: {
     ...(el.checked !== undefined ? { checked: el.checked } : {}),
     ...(el.required ? { required: true } : {}),
     inViewport: el.inViewport,
+    // The durable locator the click/fill tools echo back verbatim. This MUST
+    // be present: the tool schema tells the model to copy it from here, and it
+    // carries the closed-shadow marker that routes clicks through CDP.
+    ...(el.target ? { target: el.target } : {}),
   }))
   // Keep the full text but cap so a long page doesn't blow the context.
   const text =

--- a/src/background/cdp-shadow.ts
+++ b/src/background/cdp-shadow.ts
@@ -1,0 +1,487 @@
+/**
+ * Closed shadow-DOM support via the Chrome DevTools Protocol.
+ *
+ * Web components whose shadow root is created with `mode: 'closed'` (Xiaohongshu's
+ * `<xhs-publish-btn>` is one) expose NOTHING to JavaScript: their inner
+ * elements have no accessible shadow root, document queries never reach them,
+ * and synthetic events dispatched on the host do not cross into the shadow
+ * tree. The page's own scripts cannot see them either.
+ *
+ * The debugger protocol is the one sanctioned channel that can:
+ *   - `DOM.getDocument({ pierce: true })` expands CLOSED shadow roots (CDP's
+ *     `node.shadowRoots` is populated regardless of the root's mode);
+ *   - `Input.dispatchMouseEvent` synthesizes TRUSTED input, so the browser's
+ *     own hit-testing lands on the shadowed button and fires the page's real
+ *     listeners.
+ *
+ * The manifest already declares the `debugger` permission (the CSP fallback in
+ * driver.ts uses it). Attaching shows Chrome's "extension is debugging this
+ * tab" infobar; we attach on demand and detach immediately after.
+ *
+ * Tree parsing is split into pure functions (`buildShadowCandidates`,
+ * `matchCandidates`) so it is unit-testable without chrome.debugger; only the
+ * live node resolution / event dispatch touches the protocol.
+ *
+ * @module background/cdp-shadow
+ */
+
+import type { SnapshotElement, Target, TargetSpec } from '../lib/ops'
+
+// --- CDP node shapes (only the fields we use) -------------------------------
+
+interface CdpNode {
+  nodeId?: number
+  backendNodeId?: number
+  nodeType?: number
+  nodeName?: string
+  nodeValue?: string
+  attributes?: string[] // flat [name0, value0, name1, value1, ...]
+  children?: CdpNode[]
+  shadowRoots?: CdpNode[]
+  childNodeCount?: number
+}
+
+interface CdpBoxModel {
+  /** Flat number quad [x1,y1,x2,y2,x3,y3,x4,y4] (real CDP shape). */
+  content?: unknown
+}
+
+// --- Pure tree parsing -------------------------------------------------------
+
+/**
+ * An interactive element discovered inside a shadow root (open or closed) in
+ * the CDP-pierced tree.
+ */
+export interface ShadowCandidate {
+  tag: string
+  role: string
+  name: string
+  disabled: boolean
+  /** Chain of shadow hosts outermost-first (light-DOM tags, for narrowing). */
+  hostTags: string[]
+  /** Index of the element within the flattened candidate list, for `nth`. */
+  depth: number
+  text: string
+  node: CdpNode
+}
+
+const INTERACTIVE_TAGS = new Set([
+  'a', 'button', 'input', 'select', 'textarea', 'summary',
+])
+
+function attrMap(node: CdpNode): Record<string, string> {
+  const out: Record<string, string> = {}
+  const attrs = node.attributes ?? []
+  for (let i = 0; i + 1 < attrs.length; i += 2) {
+    const name = attrs[i]
+    const value = attrs[i + 1]
+    if (name) out[name] = value ?? ''
+  }
+  return out
+}
+
+function collapse(text: string): string {
+  return (text ?? '').replace(/[\s ]+/g, ' ').trim()
+}
+
+/** Implicit ARIA role from a tag, mirroring the kernel's `roleOf`. */
+export function roleForTag(tag: string, attrs: Record<string, string>): string {
+  const explicit = attrs.role
+  if (explicit) return explicit.trim().split(/\s+/)[0] ?? ''
+  if (tag === 'a') return attrs.href ? 'link' : 'generic'
+  if (tag === 'button') return 'button'
+  if (tag === 'select') return 'combobox'
+  if (tag === 'textarea') return 'textbox'
+  if (tag === 'summary') return 'button'
+  if (tag === 'input') {
+    const type = (attrs.type ?? 'text').toLowerCase()
+    if (type === 'checkbox') return 'checkbox'
+    if (type === 'radio') return 'radio'
+    if (['button', 'submit', 'reset', 'image'].includes(type)) return 'button'
+    if (type === 'hidden') return 'none'
+    return 'textbox'
+  }
+  return 'generic'
+}
+
+function isInteractive(tag: string, attrs: Record<string, string>): boolean {
+  if (INTERACTIVE_TAGS.has(tag)) return roleForTag(tag, attrs) !== 'none'
+  if (attrs.role) {
+    const r = attrs.role.toLowerCase()
+    if (!['presentation', 'none'].includes(r)) return true
+  }
+  if (attrs.tabindex !== undefined && attrs.tabindex !== '-1') return true
+  if (attrs.contenteditable === 'true' || attrs.contenteditable === '') return true
+  if (attrs.onclick) return true
+  return false
+}
+
+/** Visible text of a CDP node by aggregating its subtree's text children. */
+function nodeText(node: CdpNode): string {
+  let out = ''
+  const walk = (n: CdpNode): void => {
+    if (n.nodeType === 3) {
+      out += n.nodeValue ?? ''
+      return
+    }
+    if (n.nodeName && ['SCRIPT', 'STYLE', 'NOSCRIPT', 'TEMPLATE'].includes(n.nodeName)) return
+    n.children?.forEach(walk)
+  }
+  walk(node)
+  return collapse(out)
+}
+
+/**
+ * Walk the pierced DOM tree and collect interactive elements located inside a
+ * shadow root. `inShadow` flips true once we descend into any `shadowRoots`
+ * entry; elements within are candidates. Pure (tree in, candidates out).
+ */
+export function buildShadowCandidates(root: CdpNode): ShadowCandidate[] {
+  const out: ShadowCandidate[] = []
+
+  const walk = (node: CdpNode, inShadow: boolean, hostTags: string[]): void => {
+    if (node.nodeType === 1) {
+      const tag = (node.nodeName ?? '').toLowerCase()
+      const attrs = attrMap(node)
+      if (inShadow && isInteractive(tag, attrs)) {
+        const role = roleForTag(tag, attrs)
+        out.push({
+          tag,
+          role,
+          name: accessibleName(node, tag, attrs),
+          disabled:
+            attrs.disabled !== undefined ||
+            attrs['aria-disabled'] === 'true',
+          hostTags: hostTags.slice(),
+          depth: out.length,
+          text: nodeText(node),
+          node,
+        })
+      }
+      // Descend into light-DOM children first.
+      node.children?.forEach((child) => {
+        walk(child, inShadow, hostTags)
+      })
+      // Shadow roots of this host: their subtree is shadowed.
+      node.shadowRoots?.forEach((sr) => {
+        const nextHosts = inShadow ? hostTags.concat(tag) : [tag]
+        sr.children?.forEach((child) => walk(child, true, nextHosts))
+      })
+    } else {
+      // Shadow-root node (nodeType 11) reached directly, or document fragment.
+      node.children?.forEach((child) => walk(child, inShadow, hostTags))
+    }
+  }
+
+  walk(root, false, [])
+  return out
+}
+
+/** Best-effort accessible name for a CDP node (aria-label / title / value / text). */
+function accessibleName(
+  node: CdpNode,
+  tag: string,
+  attrs: Record<string, string>,
+): string {
+  const aria = collapse(attrs['aria-label'] ?? '')
+  if (aria) return aria
+  const title = collapse(attrs.title ?? '')
+  if (title) return title
+  if (tag === 'input') {
+    const type = (attrs.type ?? 'text').toLowerCase()
+    if (['button', 'submit', 'reset'].includes(type)) {
+      return collapse(attrs.value ?? '')
+    }
+    return collapse(attrs.placeholder ?? attrs.name ?? '')
+  }
+  const text = nodeText(node)
+  return text.length <= 120 ? text : text.slice(0, 120)
+}
+
+// --- Candidate matching ------------------------------------------------------
+
+/** True when a candidate satisfies a single target spec. */
+export function candidateMatches(c: ShadowCandidate, spec: TargetSpec): boolean {
+  const wantedName = spec.value
+  // For a role spec, `spec.role` carries the ARIA role and `value` the
+  // accessible name. Snapshots we produced always have role; tolerate a
+  // name-only fallback too.
+  if (spec.how === 'role' || spec.how === 'cdp-shadow') {
+    if (spec.role) {
+      if (c.role.toLowerCase() !== spec.role.toLowerCase()) return false
+    } else if (wantedName) {
+      // No role to compare (name-only spec); match on name below.
+    }
+    return !wantedName || c.name === wantedName || c.text === wantedName
+  }
+  if (spec.how === 'text' || spec.how === 'id' || spec.how === 'testid') {
+    return c.name === wantedName || c.text === wantedName
+  }
+  if (spec.how === 'css') {
+    // CSS specs normally resolve open roots in-page; for the closed path
+    // accept by name/tag embedded in the value.
+    if (!wantedName) return true
+    return c.name === wantedName || c.text === wantedName || c.tag === wantedName.toLowerCase()
+  }
+  return false
+}
+
+/** Pick the best candidate for a target (primary + fallbacks), honoring nth. */
+export function matchCandidates(
+  candidates: ShadowCandidate[],
+  target: Target,
+): ShadowCandidate | null {
+  const specs = [target.primary, ...(target.fallbacks ?? [])]
+  for (const spec of specs) {
+    if (!spec) continue
+    const matches = candidates.filter((c) => candidateMatches(c, spec))
+    if (matches.length === 0) continue
+    if (typeof spec.nth === 'number' && typeof matches[spec.nth] !== 'undefined') {
+      return matches[spec.nth] ?? null
+    }
+    return (
+      matches.find((c) => !c.disabled) ??
+      matches[0] ??
+      null
+    )
+  }
+  return null
+}
+
+/** Find candidates whose role/name resemble a free-text query (for snapshot). */
+export function findCandidatesByName(
+  candidates: ShadowCandidate[],
+  name: string,
+): ShadowCandidate[] {
+  const wanted = name.trim()
+  if (!wanted) return []
+  return candidates.filter(
+    (c) => c.name === wanted || c.text === wanted || c.name.includes(wanted),
+  )
+}
+
+// --- Live CDP operations -----------------------------------------------------
+
+export interface CdpSession {
+  send: (method: string, params?: Record<string, unknown>) => Promise<unknown>
+}
+
+/**
+ * Center of a CDP box model's content quad (viewport coordinates).
+ *
+ * The REAL CDP `DOM.getBoxModel` returns `model.content` as a FLAT number quad
+ * `[x1, y1, x2, y2, x3, y3, x4, y4]` — not an array of points. Tolerate an
+ * object-point array too (defensive; older tooling exposed that shape), and
+ * reject NaN/non-finite results so a bad box never reaches
+ * `Input.dispatchMouseEvent` as a null/NaN coordinate (the CDP binder fails
+ * with "mandatory field missing" for a null x/y).
+ */
+export function boxCenter(
+  box: { model?: CdpBoxModel; content?: unknown } | undefined,
+): { x: number; y: number } | null {
+  const raw = box?.model?.content ?? box?.content
+  if (!Array.isArray(raw) || raw.length === 0) return null
+  const points: Array<{ x: number; y: number }> = []
+  if (typeof raw[0] === 'number') {
+    // Flat quad: 4 points × 2 coordinates.
+    if (raw.length < 8) return null
+    for (let i = 0; i + 1 < raw.length; i += 2) {
+      points.push({ x: raw[i] as number, y: raw[i + 1] as number })
+    }
+  } else {
+    if (raw.length < 4) return null
+    for (const p of raw) {
+      const pt = p as { x?: unknown; y?: unknown } | null
+      if (!pt || typeof pt.x !== 'number' || typeof pt.y !== 'number') return null
+      points.push({ x: pt.x, y: pt.y })
+    }
+  }
+  if (points.length < 4) return null
+  let x = 0
+  let y = 0
+  for (const p of points) {
+    x += p.x
+    y += p.y
+  }
+  const cx = x / points.length
+  const cy = y / points.length
+  if (!Number.isFinite(cx) || !Number.isFinite(cy)) return null
+  return { x: cx, y: cy }
+}
+
+/** Convert a shadow candidate into a snapshot element entry. */
+export function candidateToSnapshot(
+  c: ShadowCandidate,
+  ref: string,
+): SnapshotElement {
+  const primary: TargetSpec = {
+    how: 'cdp-shadow',
+    value: c.name || c.tag,
+    role: c.role,
+    tag: c.tag,
+    closedShadow: true,
+    // Host tags are descriptive (the closed root is re-discovered from the
+    // pierced tree at click time, not reached via these selectors).
+    shadowHosts: c.hostTags.slice(),
+  }
+  const target: Target = { primary, fallbacks: [], label: c.name || c.tag }
+  const entry: SnapshotElement = {
+    ref,
+    role: c.role,
+    name: c.name,
+    tag: c.tag,
+    inViewport: true,
+    target,
+  }
+  if (c.disabled) entry.disabled = true
+  return entry
+}
+
+/**
+ * Read all interactive elements inside shadow roots (incl. closed) via CDP.
+ * Returns snapshot entries with refs continuing from `startRef`.
+ */
+export async function snapshotClosedShadow(
+  session: CdpSession,
+  startRef: number,
+): Promise<SnapshotElement[]> {
+  const doc = (await session.send('DOM.getDocument', {
+    depth: -1,
+    pierce: true,
+  })) as { root?: CdpNode }
+  const candidates = buildShadowCandidates(doc.root ?? ({} as CdpNode))
+  if (candidates.length === 0) return []
+
+  const entries: SnapshotElement[] = []
+  let ref = startRef
+  // Resolve box models to filter out non-rendered elements; one CDP call per
+  // candidate is acceptable because shadowed interactive elements are few.
+  for (const c of candidates) {
+    const nodeId = c.node.nodeId
+    if (typeof nodeId !== 'number') continue
+    let box: { model?: CdpBoxModel; content?: unknown } | undefined
+    try {
+      box = (await session.send('DOM.getBoxModel', { nodeId })) as typeof box
+    } catch {
+      box = undefined
+    }
+    const center = boxCenter(box)
+    if (!center) continue // not rendered / display:none
+    const entry = candidateToSnapshot(c, `e${ref}`)
+    entries.push(entry)
+    ref += 1
+  }
+  return entries
+}
+
+/**
+ * Last-resort click for a node whose box model is unavailable: resolve it to
+ * a Runtime object and invoke `this.click()` on it. The event is untrusted
+ * (isTrusted === false), so pages that gate on real input still need the
+ * Input-dispatch path — but plain addEventListener handlers fire.
+ */
+async function syntheticClickNode(
+  session: CdpSession,
+  nodeId: number,
+): Promise<{ ok: boolean; note?: string; error?: string }> {
+  try {
+    const resolved = (await session.send('DOM.resolveNode', { nodeId })) as {
+      object?: { objectId?: string }
+    }
+    const objectId = resolved.object?.objectId
+    if (!objectId) {
+      return { ok: false, error: '元素未渲染（没有可见尺寸），且节点无法解析，无法点击。' }
+    }
+    await session.send('Runtime.callFunctionOn', {
+      objectId,
+      functionDeclaration: 'function () { this.click(); }',
+      returnByValue: true,
+    })
+    return { ok: true, note: '已通过节点回退方式点击（合成 click，非受信任事件）' }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { ok: false, error: `元素未渲染且回退点击失败：${message}` }
+  }
+}
+
+/**
+ * Click (or hover) an element inside a closed shadow root via trusted CDP
+ * input events. Resolves the target inside the pierced tree, scrolls it into
+ * view, and dispatches real mouse input at its center — input the browser
+ * hit-tests through the shadow boundary.
+ *
+ * @returns a human-readable outcome.
+ */
+export async function clickClosedShadow(
+  session: CdpSession,
+  target: Target,
+  kind: 'click' | 'hover' = 'click',
+): Promise<{ ok: boolean; note?: string; error?: string }> {
+  const doc = (await session.send('DOM.getDocument', {
+    depth: -1,
+    pierce: true,
+  })) as { root?: CdpNode }
+  const candidates = buildShadowCandidates(doc.root ?? ({} as CdpNode))
+  const match = matchCandidates(candidates, target)
+  if (!match) {
+    return {
+      ok: false,
+      error: `封闭 Shadow DOM 中未找到匹配元素（${target.primary.how}: ${target.primary.value}）。`,
+    }
+  }
+  const nodeId = match.node.nodeId
+  if (typeof nodeId !== 'number') {
+    return { ok: false, error: '匹配到的元素缺少 nodeId，无法操作。' }
+  }
+
+  try {
+    await session.send('DOM.scrollIntoViewIfNeeded', { nodeId })
+  } catch {
+    /* not scrollable / unsupported; the box coordinates still apply */
+  }
+
+  let box: { model?: CdpBoxModel; content?: unknown } | undefined
+  try {
+    box = (await session.send('DOM.getBoxModel', { nodeId })) as typeof box
+  } catch {
+    box = undefined
+  }
+  const center = boxCenter(box)
+  if (!center) {
+    // Box unavailable (not rendered / zero size): fall back to a synthetic DOM
+    // click on the resolved node — CDP holds the node even inside a closed
+    // shadow root, so this still reaches the page's own click listeners.
+    return syntheticClickNode(session, nodeId)
+  }
+
+  const at = { x: Math.round(center.x), y: Math.round(center.y) }
+  if (kind === 'hover') {
+    // A trusted mouseMoved: the browser fires pointerover/mouseover chain on
+    // the shadowed element under the cursor.
+    await session.send('Input.dispatchMouseEvent', {
+      ...at,
+      type: 'mouseMoved',
+      button: 'none',
+      buttons: 0,
+    })
+    return { ok: true, note: `已悬停 ${match.tag}「${match.name || match.text}」` }
+  }
+
+  // Trusted click sequence: press then release. The browser fires the full
+  // pointer/mouse/click chain at the shadowed element under the cursor.
+  await session.send('Input.dispatchMouseEvent', {
+    ...at,
+    type: 'mousePressed',
+    button: 'left',
+    buttons: 1,
+    clickCount: 1,
+  })
+  await session.send('Input.dispatchMouseEvent', {
+    ...at,
+    type: 'mouseReleased',
+    button: 'left',
+    buttons: 0,
+    clickCount: 1,
+  })
+  return { ok: true, note: `已点击 ${match.tag}「${match.name || match.text}」` }
+}

--- a/src/background/driver.ts
+++ b/src/background/driver.ts
@@ -16,10 +16,15 @@
  */
 
 import { isInjectablePage } from '../lib/pages'
-import type { Op, OpResult, PageSnapshot } from '../lib/ops'
+import type { Op, OpResult, PageSnapshot, SnapshotElement, Target } from '../lib/ops'
 import { runOp, runExecJs, runWorkflowJs } from '../inpage/kernel'
 import { activeTab } from './page'
 import { getLastInjectableTab } from './last-tab'
+import {
+  clickClosedShadow,
+  snapshotClosedShadow,
+  type CdpSession,
+} from './cdp-shadow'
 
 /**
  * Resolve the tab a workflow should act on.
@@ -184,6 +189,23 @@ export async function execOnActiveTab(
     return runWorkflowJsInMainWorld(tab, op, signal)
   }
 
+  // Actions on elements inside a CLOSED shadow root cannot be performed by
+  // in-page JS (the root is inaccessible); drive them through CDP trusted
+  // input. Click/hover are supported; other targeted actions report a clear
+  // error instead of the kernel's generic "not matched".
+  if (typeof tab.id === 'number' && targetIsClosedShadow(op.target)) {
+    if (op.action === 'click' || op.action === 'hover') {
+      return runClosedShadowAction(tab.id, tab.url ?? '', op)
+    }
+    return {
+      ok: false,
+      found: true,
+      frameUrl: tab.url ?? '',
+      isTopFrame: true,
+      error: `该元素位于封闭 Shadow DOM 中，暂不支持 ${op.action} 操作；可改用「JavaScript 代码」块在页面主世界执行。`,
+    }
+  }
+
   let injections: chrome.scripting.InjectionResult<unknown>[]
   try {
     injections = await abortable(
@@ -224,7 +246,72 @@ export async function execOnActiveTab(
   const rank = (result: OpResult): number =>
     (result.found ? 4 : 0) + (result.ok ? 2 : 0) + (result.isTopFrame ? 1 : 0)
   results.sort((a, b) => rank(b) - rank(a))
-  return results[0] as OpResult
+  const best = results[0] as OpResult
+
+  // Enrich a snapshot with interactive elements hidden inside CLOSED shadow
+  // roots (in-page JS never sees them). Best-effort: when the debugger is
+  // unavailable or attaching fails, return the kernel snapshot unchanged.
+  // They are PREPENDED and renumbered after the kernel elements so they never
+  // fall beyond the model-facing element cap (shadowed controls are rare and
+  // the whole reason for this enrichment).
+  if (op.action === 'snapshot' && best.ok && best.page && chrome.debugger) {
+    const extra = await readClosedShadowElements(tab.id)
+    if (extra.length > 0) {
+      const kernelCount = best.page.elements.length
+      const renumbered = best.page.elements.map((el, i) => ({ ...el, ref: `e${i + 1}` }))
+      const shadowEntries = extra.map((el, i) => ({ ...el, ref: `e${kernelCount + i + 1}` }))
+      best.page = {
+        ...best.page,
+        elements: shadowEntries.concat(renumbered),
+      }
+    }
+  }
+  return best
+}
+
+/** Snapshot interactive elements inside closed shadow roots via CDP. */
+async function readClosedShadowElements(tabId: number): Promise<SnapshotElement[]> {
+  try {
+    return await withCdpSession(tabId, (session) => snapshotClosedShadow(session, 1))
+  } catch {
+    // User dismissed the infobar / debugger policy / attach failed — degrade
+    // silently: light-DOM and open-shadow elements are already in the snapshot.
+    return []
+  }
+}
+
+/** Run a click/hover on a closed-shadow element via CDP trusted input. */
+async function runClosedShadowAction(
+  tabId: number,
+  frameUrl: string,
+  op: Op,
+): Promise<OpResult> {
+  const base: OpResult = { ok: false, found: true, frameUrl, isTopFrame: true }
+  if (!chrome.debugger) {
+    return {
+      ...base,
+      found: false,
+      error:
+        '该元素位于封闭 Shadow DOM 中，需要调试器（chrome.debugger）权限才能操作；当前环境不可用。',
+    }
+  }
+  try {
+    const kind = op.action === 'hover' ? 'hover' as const : 'click' as const
+    const out = await withCdpSession(tabId, (session) =>
+      clickClosedShadow(session, op.target as Target, kind),
+    )
+    if (out.ok) {
+      return { ...base, ok: true, note: out.note ?? '已操作（封闭 Shadow DOM）' }
+    }
+    return { ...base, found: false, error: out.error ?? '未能点击封闭 Shadow DOM 中的元素。' }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      ...base,
+      found: false,
+      error: `封闭 Shadow DOM 操作失败：${message}。可尝试在页面上用「JavaScript 代码」块直接操作，或允许扩展调试该标签页。`,
+    }
+  }
 }
 
 /**
@@ -251,6 +338,67 @@ function explainJsError(message: string): string {
 }
 
 /**
+ * Whether a target lives inside a CLOSED shadow root (any spec so marked).
+ * Such targets cannot be resolved by in-page JS; the driver routes them to
+ * the chrome.debugger (CDP) channel.
+ */
+function targetIsClosedShadow(target: Target | undefined): boolean {
+  if (!target) return false
+  return [target.primary, ...(target.fallbacks ?? [])].some(
+    (spec) => spec && (spec.how === 'cdp-shadow' || spec.closedShadow === true),
+  )
+}
+
+/**
+ * Serialize CDP sessions per tab so a CSP-fallback eval and a shadow click
+ * never interleave attach/detach against the same target. Each caller attaches
+ * (tolerating an existing attachment), runs, and detaches; the queue makes
+ * those sessions run one at a time.
+ */
+const cdpQueues = new Map<number, Promise<unknown>>()
+
+function withCdpSession<T>(
+  tabId: number,
+  fn: (session: CdpSession) => Promise<T>,
+): Promise<T> {
+  const run = async (): Promise<T> => {
+    const target = { tabId }
+    try {
+      await chrome.debugger.attach(target, '1.3')
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      if (!/already attached|already being debugged/i.test(msg)) throw error
+    }
+    let attachedByUs = true
+    try {
+      const session: CdpSession = {
+        send: (method: string, params?: Record<string, unknown>) =>
+          chrome.debugger.sendCommand(target, method, params) as Promise<unknown>,
+      }
+      return await fn(session)
+    } finally {
+      // Only detach if we attached; another session may own a long-lived one.
+      if (attachedByUs) {
+        try {
+          await chrome.debugger.detach(target)
+        } catch {
+          /* may already be detached */
+        }
+      }
+    }
+  }
+  const prev = cdpQueues.get(tabId) ?? Promise.resolve()
+  const next = prev.then(run, run)
+  cdpQueues.set(
+    tabId,
+    next.finally(() => {
+      if (cdpQueues.get(tabId) === next) cdpQueues.delete(tabId)
+    }),
+  )
+  return next as Promise<T>
+}
+
+/**
  * Evaluate code in the page's MAIN world via the Chrome DevTools Protocol
  * (`chrome.debugger` + `Runtime.evaluate`). This is the CSP bypass Automa uses:
  * DevTools evaluation runs in the page's real JS context (so `window`, page
@@ -262,31 +410,8 @@ function explainJsError(message: string): string {
  * JSON-serializable result value, or rejects with the runtime/attach error.
  */
 async function evalViaCdp(tabId: number, expression: string): Promise<unknown> {
-  const target = { tabId }
-  const attach = async (): Promise<void> => {
-    try {
-      await chrome.debugger.attach(target, '1.3')
-    } catch (error) {
-      // Already attached (e.g. a previous run didn't detach) — reuse it.
-      const msg = error instanceof Error ? error.message : String(error)
-      if (!/already attached|already being debugged/i.test(msg)) throw error
-    }
-  }
-
-  await attach()
-  let attached = true
-  const detach = async (): Promise<void> => {
-    if (!attached) return
-    attached = false
-    try {
-      await chrome.debugger.detach(target)
-    } catch {
-      /* may already be detached */
-    }
-  }
-
-  try {
-    const res = (await chrome.debugger.sendCommand(target, 'Runtime.evaluate', {
+  return withCdpSession(tabId, async (session) => {
+    const res = (await session.send('Runtime.evaluate', {
       expression,
       // Evaluate in the page's top frame MAIN world (the default context),
       // await Promises, and surface thrown errors as exceptionDetails.
@@ -306,9 +431,7 @@ async function evalViaCdp(tabId: number, expression: string): Promise<unknown> {
       throw new DriverError(desc.split('\n')[0] || desc)
     }
     return res.result?.value
-  } finally {
-    await detach()
-  }
+  })
 }
 
 /**

--- a/src/inpage/element-picker/index.ts
+++ b/src/inpage/element-picker/index.ts
@@ -110,17 +110,26 @@ export const startPicker: PickerStart = async (args) => {
     }
     return (opts.tagName ? tag : '') + q
   }
+  // Count matches of a CSS selector across all open roots, and whether `el`
+  // is the (only) match — shadow elements never appear in document queries.
+  const matchesInRoots = (sel: string): Element[] => {
+    const out: Element[] = []
+    for (const root of openRoots()) {
+      try { root.querySelectorAll(sel).forEach((m) => out.push(m)) } catch { /* bad selector */ }
+    }
+    return out
+  }
   function build(el: Element): string {
     const direct = part(el)
-    if (direct.startsWith('#') && document.querySelectorAll(direct).length === 1) return direct
+    if (direct.startsWith('#') && matchesInRoots(direct).length === 1) return direct
     const chain = [direct]
     let node: Element | null = el.parentElement
     let depth = 0
     while (node && depth < 6) {
       const cand = chain.slice().reverse().join(' > ')
-      const ms = document.querySelectorAll(cand)
+      const ms = matchesInRoots(cand)
       if (ms.length === 1 && ms[0] === el) return cand
-      if (opts.idName && node.id) { const withId = `#${esc(node.id)} > ${chain.slice().reverse().join(' > ')}`; if (document.querySelectorAll(withId).length === 1) return withId }
+      if (opts.idName && node.id) { const withId = `#${esc(node.id)} > ${chain.slice().reverse().join(' > ')}`; if (matchesInRoots(withId).length === 1) return withId }
       chain.push(part(node)); node = node.parentElement; depth++
     }
     return chain.slice().reverse().join(' > ')
@@ -140,12 +149,38 @@ export const startPicker: PickerStart = async (args) => {
     }
     return segs.join('')
   }
+  // Collect the document plus every OPEN shadow root (outermost first) so the
+  // selector matcher can reach inside web components. The picker host itself
+  // is excluded (its open shadow root is our own card). Closed shadow roots
+  // are invisible to JS; those targets are driven via chrome.debugger.
+  const openRoots = (): ParentNode[] => {
+    const roots: ParentNode[] = [document]
+    const visit = (root: ParentNode): void => {
+      let list: NodeListOf<Element>
+      try { list = root.querySelectorAll('*') } catch { return }
+      list.forEach((el) => {
+        if (el === host) return
+        const sr = (el as HTMLElement).shadowRoot
+        if (sr && sr.nodeType === 11) { roots.push(sr); visit(sr) }
+      })
+    }
+    visit(document)
+    return roots
+  }
   const count = (sel: string, xp: boolean): number => {
     if (!sel) return 0
+    let n = 0
     try {
-      if (xp) return document.evaluate(sel, document, null, 7, null).snapshotLength
-      return document.querySelectorAll(sel).length
+      for (const root of openRoots()) {
+        if (xp) {
+          const doc = root.nodeType === 9 ? (root as Document) : (root as ShadowRoot).ownerDocument
+          if (doc) n += doc.evaluate(sel, root, null, 7, null).snapshotLength
+        } else {
+          n += root.querySelectorAll(sel).length
+        }
+      }
     } catch { return 0 }
+    return n
   }
 
   // --- DOM scaffold (Shadow DOM) ---
@@ -253,10 +288,26 @@ export const startPicker: PickerStart = async (args) => {
     return
   }
 
+  // Deepest element under a mouse event, crossing OPEN shadow boundaries.
+  // composedPath()[0] is the real target inside an open shadow root; for a
+  // closed root the path is truncated to the host, matching elementFromPoint.
+  const eventTarget = (e: MouseEvent): Element | null => {
+    const path = e.composedPath?.()
+    const first = path && path[0]
+    return (first as Element) ?? document.elementFromPoint(e.clientX, e.clientY)
+  }
+  // Our own UI (the picker card lives in `host`'s open shadow root): any event
+  // whose path passes through `host` is a click inside the card.
+  const isOurUi = (e: MouseEvent): boolean => {
+    const path = e.composedPath?.()
+    if (path && path.indexOf(host) !== -1) return true
+    const t = e.target as Node | null
+    return !!t && host.contains(t)
+  }
   const onMove = (e: MouseEvent) => {
     if (locked) return
-    hovered = document.elementFromPoint(e.clientX, e.clientY)
-    if (hovered && (hovered === card || (card.contains(hovered)) || host.contains(hovered))) {
+    hovered = eventTarget(e)
+    if (hovered && (hovered === card || card.contains(hovered) || host.contains(hovered))) {
       hovered = null
       highlightEl(null)
       return
@@ -279,11 +330,11 @@ export const startPicker: PickerStart = async (args) => {
     // the editor spinner spun forever. Return BEFORE preventDefault /
     // stopPropagation so card clicks reach their shadow listeners (and
     // checkbox/select defaults inside the card keep working).
-    if (host.contains(e.target as Node)) return
+    if (isOurUi(e)) return
     e.preventDefault()
     e.stopPropagation()
-    locked = hovered ?? document.elementFromPoint(e.clientX, e.clientY)
-    if (locked && !host.contains(locked)) refresh()
+    locked = eventTarget(e)
+    if (locked && locked !== host && !host.contains(locked)) refresh()
   }
   const onKey = (e: KeyboardEvent) => {
     if (e.key === 'Escape') { cleanup(); void chrome.runtime.sendMessage({ type: 'picker:cancel', pickerId }) }

--- a/src/inpage/kernel.ts
+++ b/src/inpage/kernel.ts
@@ -294,50 +294,131 @@ export function runOp(op: Op): OpResult {
     return parts.join('|')
   }
 
-  function safeQuery(selector: string): Element[] {
-    try {
-      return Array.prototype.slice.call(document.querySelectorAll(selector)) as Element[]
-    } catch {
-      return []
-    }
-  }
-  /** Resolve an XPath expression to element matches (7 = ORDERED_NODE_SNAPSHOT). */
-  function xpathQuery(xpath: string): Element[] {
-    try {
-      const result = document.evaluate(xpath, document, null, 7, null)
-      const out: Element[] = []
-      for (let i = 0; i < result.snapshotLength; i++) {
-        const n = result.snapshotItem(i)
-        if (n && (n as Node).nodeType === 1) out.push(n as Element)
+  /**
+   * Every root the kernel can query: the document plus each OPEN shadow root,
+   * outermost first (shadow roots are discovered by walking hosts). A CLOSED
+   * shadow root's `.shadowRoot` is null — invisible to JS by design; those
+   * targets are resolved by the driver's chrome.debugger (CDP) channel.
+   */
+  function openRoots(): ParentNode[] {
+    const roots: ParentNode[] = [document]
+    const visit = (root: ParentNode): void => {
+      let hosts: NodeListOf<Element>
+      try {
+        hosts = root.querySelectorAll('*')
+      } catch {
+        return
       }
-      return out
-    } catch {
-      return []
+      for (let i = 0; i < hosts.length; i += 1) {
+        const el = hosts[i]
+        if (!el) continue
+        const sr = (el as HTMLElement).shadowRoot
+        if (sr && sr.nodeType === 11) {
+          roots.push(sr)
+          visit(sr)
+        }
+      }
     }
+    visit(document)
+    return roots
   }
+
+  function querySelectorIn(roots: ParentNode[], selector: string): Element[] {
+    const out: Element[] = []
+    for (const root of roots) {
+      try {
+        const list = root.querySelectorAll(selector)
+        for (let i = 0; i < list.length; i += 1) {
+          const el = list[i]
+          if (el) out.push(el)
+        }
+      } catch {
+        /* invalid selector for this root */
+      }
+    }
+    return out
+  }
+
+  /** Query every open root (document + open shadow roots). */
+  function safeQuery(selector: string): Element[] {
+    return querySelectorIn(openRoots(), selector)
+  }
+
+  /** Resolve an XPath in one root (7 = ORDERED_NODE_SNAPSHOT). */
+  function xpathInRoots(roots: ParentNode[], xpath: string): Element[] {
+    const out: Element[] = []
+    for (const root of roots) {
+      try {
+        const doc =
+          root.nodeType === 9 ? (root as Document) : (root as ShadowRoot).ownerDocument
+        if (!doc) continue
+        const result = doc.evaluate(xpath, root, null, 7, null)
+        for (let i = 0; i < result.snapshotLength; i += 1) {
+          const n = result.snapshotItem(i)
+          if (n && (n as Node).nodeType === 1) out.push(n as Element)
+        }
+      } catch {
+        /* bad expression in this root */
+      }
+    }
+    return out
+  }
+
+  /**
+   * Follow a shadow-host chain (each entry a CSS selector for a host within
+   * its parent root) and return the final root to query inside. Returns null
+   * when there is no chain (caller queries every open root), or an empty array
+   * when the chain cannot be followed — notably a CLOSED shadow root, which JS
+   * cannot enter (the driver routes those ops through chrome.debugger).
+   */
+  function descendShadowHosts(hosts: string[] | undefined): ParentNode[] | null {
+    if (!hosts || hosts.length === 0) return null
+    let root: ParentNode = document
+    for (let i = 0; i < hosts.length; i += 1) {
+      const hostSel = hosts[i] as string
+      let host: Element | null = null
+      try {
+        host = root.querySelector(hostSel)
+      } catch {
+        host = null
+      }
+      if (!host) return []
+      const sr = (host as HTMLElement).shadowRoot
+      if (!sr) return [] // closed shadow root (or host changed): unreachable in-page
+      root = sr
+    }
+    return [root]
+  }
+
   function queryAll(spec: TargetSpec): Element[] {
+    // Specs produced for CLOSED shadow-root elements are never resolvable
+    // in-page; the kernel skips them so the driver routes the op through CDP.
+    if (spec.how === 'cdp-shadow' || spec.closedShadow) return []
+    const descended = descendShadowHosts(spec.shadowHosts)
+    const roots = descended ?? openRoots()
+    if (roots.length === 0) return []
     const tagPrefix = spec.tag ?? ''
     switch (spec.how) {
       case 'testid': {
         const sep = spec.value.indexOf('=')
         const attr = sep === -1 ? 'data-testid' : spec.value.slice(0, sep)
         const value = sep === -1 ? spec.value : spec.value.slice(sep + 1)
-        return safeQuery(`${tagPrefix}[${attr}=${quoteAttr(value)}]`)
+        return querySelectorIn(roots, `${tagPrefix}[${attr}=${quoteAttr(value)}]`)
       }
       case 'id':
-        return safeQuery(`${tagPrefix}[id=${quoteAttr(spec.value)}]`)
+        return querySelectorIn(roots, `${tagPrefix}[id=${quoteAttr(spec.value)}]`)
       case 'name':
-        return safeQuery(`${tagPrefix}[name=${quoteAttr(spec.value)}]`)
+        return querySelectorIn(roots, `${tagPrefix}[name=${quoteAttr(spec.value)}]`)
       case 'css':
         // XPath locators are encoded with an `xpath:` prefix by the engine
         // (Automa blocks can set findBy='xpath'); resolve them via evaluate.
         if (spec.value.startsWith('xpath:')) {
-          return xpathQuery(spec.value.slice('xpath:'.length))
+          return xpathInRoots(roots, spec.value.slice('xpath:'.length))
         }
-        return safeQuery(spec.value)
+        return querySelectorIn(roots, spec.value)
       case 'role': {
         const wanted = (spec.role ?? '').toLowerCase()
-        const all = safeQuery('*')
+        const all = querySelectorIn(roots, '*')
         const found: Element[] = []
         for (const candidate of all) {
           if (roleOf(candidate).toLowerCase() !== wanted) continue
@@ -348,7 +429,7 @@ export function runOp(op: Op): OpResult {
       }
       case 'text': {
         const wanted = spec.value
-        const all = safeQuery(tagPrefix || '*')
+        const all = querySelectorIn(roots, tagPrefix || '*')
         const exact: Element[] = []
         for (const candidate of all) {
           if (visibleText(candidate) !== wanted) continue
@@ -368,10 +449,39 @@ export function runOp(op: Op): OpResult {
     }
   }
 
+  /**
+   * For an element inside an OPEN shadow root, the chain of shadow hosts from
+   * the document root to it (outermost first), each as a selector relative to
+   * the root it lives in (cssPath stops at the shadow boundary, so each step is
+   * scoped to its own root). Empty for light-DOM elements. The spec is
+   * annotated with it so `queryAll` descends back into the same open roots.
+   */
+  function shadowHostChain(element: Element): string[] {
+    const hosts: string[] = []
+    let el: Element | null = element
+    let root: Node = el.getRootNode ? el.getRootNode() : el.ownerDocument
+    // nodeType 11 === DOCUMENT_FRAGMENT_NODE (a ShadowRoot). Walk out through
+    // every shadow boundary; cssPath stops at the boundary, so each host step
+    // is relative to the root it lives in.
+    while (root && root.nodeType === 11) {
+      const host = (root as ShadowRoot).host
+      if (!host) break
+      hosts.unshift(cssPath(host))
+      el = host
+      root = host.getRootNode ? host.getRootNode() : host.ownerDocument
+    }
+    void el
+    return hosts
+  }
+
   function specsFor(element: Element): TargetSpec[] {
     const specs: TargetSpec[] = []
     const tag = element.tagName.toLowerCase()
-    const withIndex = (spec: TargetSpec): TargetSpec => {
+    const shadowHosts = shadowHostChain(element)
+    const scope = (spec: TargetSpec): TargetSpec =>
+      shadowHosts.length ? { ...spec, shadowHosts } : spec
+    const withIndex = (raw: TargetSpec): TargetSpec => {
+      const spec = scope(raw)
       const matches = queryAll(spec)
       if (matches.length <= 1) return spec
       const position = matches.indexOf(element)
@@ -554,7 +664,33 @@ export function runOp(op: Op): OpResult {
     const x = rect.left + rect.width / 2
     const y = rect.top + rect.height / 2
     const top = document.elementFromPoint(x, y)
-    if (!top || top === element || element.contains(top) || top.contains(element)) return null
+    if (!top || top === element) return null
+    // Light-DOM containment: the hit target is the element or an ancestor/
+    // descendant of it in the same tree.
+    if (element.contains(top) || top.contains(element)) return null
+    // Shadow DOM: elementFromPoint returns the LIGHT-DOM shadow HOST, never the
+    // shadowed element beneath. The hit reaches `element` when element is on
+    // the hit test's composed path (open shadow), or the hit host is any host
+    // in element's own host chain.
+    const elementRoot = element.getRootNode ? element.getRootNode() : element.ownerDocument
+    if (elementRoot && (elementRoot as ShadowRoot).nodeType === 11) {
+      try {
+        const path = typeof document.elementsFromPoint === 'function'
+          ? document.elementsFromPoint(x, y)
+          : [top]
+        for (let i = 0; i < path.length; i += 1) {
+          if (path[i] === element) return null
+        }
+      } catch {
+        /* fall through to host-chain check */
+      }
+      let root: Node = elementRoot
+      while (root && (root as ShadowRoot).nodeType === 11) {
+        const host = (root as ShadowRoot).host
+        if (host === top) return null
+        root = host && host.getRootNode ? host.getRootNode() : host?.ownerDocument
+      }
+    }
     return top
   }
 
@@ -627,7 +763,26 @@ export function runOp(op: Op): OpResult {
     for (const form of safeQuery('form')) {
       if (!isVisible(form)) continue
       const fields: PageSnapshot['forms'][number]['fields'] = []
-      const controls = form.querySelectorAll('input, select, textarea')
+      // Form controls can live in light DOM or in an open shadow root within
+      // the form's subtree; gather from every open root and keep only those
+      // inside this form's composed subtree (the form itself, or a field whose
+      // host chain leads up to it).
+      const controls: Element[] = []
+      for (const ctrl of querySelectorIn(openRoots(), 'input, select, textarea')) {
+        if (form.contains(ctrl)) {
+          controls.push(ctrl)
+          continue
+        }
+        // Field inside a shadow root contained in the form: walk host chain.
+        let hostNode: Node | null = ctrl.getRootNode ? ctrl.getRootNode() : ctrl.ownerDocument
+        let within = false
+        while (hostNode && (hostNode as ShadowRoot).nodeType === 11) {
+          const h: Element | null = (hostNode as ShadowRoot).host
+          if (h && form.contains(h)) { within = true; break }
+          hostNode = h ? (h.getRootNode ? h.getRootNode() : h.ownerDocument) : null
+        }
+        if (within) controls.push(ctrl)
+      }
       for (let i = 0; i < controls.length; i += 1) {
         const control = controls[i]
         if (!control || !isVisible(control)) continue

--- a/src/inpage/record/index.ts
+++ b/src/inpage/record/index.ts
@@ -56,16 +56,46 @@ export const startRecorder: RecorderStart = (args) => {
     }
     return tag + q
   }
+  // Open shadow roots to query across (excluding our own recorder bar / picker
+  // hosts, whose shadow roots are extension UI rather than page content).
+  const openRoots = (): ParentNode[] => {
+    const roots: ParentNode[] = [document]
+    const visit = (root: ParentNode): void => {
+      const list = root.querySelectorAll('*')
+      for (let i = 0; i < list.length; i += 1) {
+        const h = list[i] as Element
+        if (h.id === 'bc-element-picker' || h.id === 'bc-recorder-bar') continue
+        const sr = (h as HTMLElement).shadowRoot
+        if (sr && sr.nodeType === 11) { roots.push(sr); visit(sr) }
+      }
+    }
+    visit(document)
+    return roots
+  }
+  const countInRoots = (sel: string): { count: number; matches: Element[] } => {
+    let count = 0
+    const matches: Element[] = []
+    try {
+      for (const root of openRoots()) {
+        const ms = root.querySelectorAll(sel)
+        count += ms.length
+        ms.forEach((m) => matches.push(m))
+      }
+    } catch {
+      /* invalid selector */
+    }
+    return { count, matches }
+  }
   function selectorFor(el: Element): string {
     const direct = partOf(el)
-    if (direct.startsWith('#') && document.querySelectorAll(direct).length === 1) return direct
+    if (direct.startsWith('#') && countInRoots(direct).count === 1) return direct
     const chain = [direct]
     let node: Element | null = el.parentElement
     let depth = 0
     while (node && depth < 5) {
       const cand = chain.slice().reverse().join(' > ')
-      const ms = document.querySelectorAll(cand)
-      if (ms.length === 1 && ms[0] === el) return cand
+      const { count, matches } = countInRoots(cand)
+      if (count === 1 && matches[0] === el) return cand
       chain.push(partOf(node))
       node = node.parentElement
       depth++
@@ -168,13 +198,13 @@ export const startRecorder: RecorderStart = (args) => {
   }
 
   function onFocusIn(e: FocusEvent) {
-    const el = e.target as Element | null
+    const el = eventTarget(e)
     if (!el || isOurUi(el) || !isEditable(el)) return
     ;(el as HTMLElement).dataset.__bcSel = selectorFor(el)
     el.addEventListener('input', onInputField, true)
   }
   function onFocusOut(e: FocusEvent) {
-    const el = e.target as Element | null
+    const el = eventTarget(e)
     if (!el || !isEditable(el)) return
     el.removeEventListener('input', onInputField, true)
     // Flush any pending typing into a forms block before the field loses focus.
@@ -189,12 +219,12 @@ export const startRecorder: RecorderStart = (args) => {
     sendFormsText(el, pending?.selector ?? (el as HTMLElement).dataset.__bcSel ?? selectorFor(el), pending?.name ?? textFieldName(el))
   }
   function onInputField(e: Event) {
-    const el = e.target as Element | null
+    const el = eventTarget(e)
     if (el && isEditable(el)) recordText(el, false)
   }
 
   function onClick(e: MouseEvent) {
-    const el = e.target as Element | null
+    const el = eventTarget(e)
     if (!el || isOurUi(el)) return
 
     // Anchor -> link block.
@@ -243,7 +273,7 @@ export const startRecorder: RecorderStart = (args) => {
   }
 
   function onChange(e: Event) {
-    const el = e.target as Element | null
+    const el = eventTarget(e)
     if (!el || isOurUi(el)) return
 
     if (el.tagName === 'SELECT') {
@@ -278,7 +308,7 @@ export const startRecorder: RecorderStart = (args) => {
     'ArrowLeft', 'ArrowRight', 'Home', 'End', 'PageUp', 'PageDown', ' ',
   ])
   function onKeydown(e: KeyboardEvent) {
-    const el = e.target as Element | null
+    const el = eventTarget(e)
     if (el && isOurUi(el)) return
     const typing = el ? isEditable(el) : false
 
@@ -324,8 +354,36 @@ export const startRecorder: RecorderStart = (args) => {
     })
   }
 
+  /**
+   * Deepest event target crossing OPEN shadow boundaries. Capture listeners
+   * see a retargeted host for shadowed events, so e.target would record the
+   * host instead of the button inside. composedPath()[0] is the real element
+   * inside an open root; for a CLOSED root it is the host (unreachable in JS;
+   * those interactions are driven via chrome.debugger, not recorded).
+   */
+  function eventTarget(e: Event): Element | null {
+    const path = e.composedPath?.()
+    const first = path && path[0]
+    if (first && (first as Node).nodeType === 1) return first as Element
+    return (e.target as Element | null) ?? null
+  }
+
+  function isOurUiEl(el: Element | null): boolean {
+    if (!el) return false
+    if (el.closest('#bc-element-picker, #bc-recorder-bar')) return true
+    // Inside an open shadow root: walk the host chain (closest() does not
+    // cross shadow boundaries).
+    let root: Node = el.getRootNode ? el.getRootNode() : el.ownerDocument
+    while (root && (root as ShadowRoot).nodeType === 11) {
+      const host = (root as ShadowRoot).host
+      if (host && host.closest('#bc-element-picker, #bc-recorder-bar')) return true
+      root = host && host.getRootNode ? host.getRootNode() : host?.ownerDocument
+    }
+    return false
+  }
+
   function isOurUi(el: Element): boolean {
-    return !!el.closest('#bc-element-picker, #bc-recorder-bar')
+    return isOurUiEl(el)
   }
 
   document.addEventListener('click', onClick, true)

--- a/src/lib/ops.ts
+++ b/src/lib/ops.ts
@@ -26,12 +26,31 @@ export interface Target {
 
 /** One way of locating an element. */
 export interface TargetSpec {
-  how: 'testid' | 'id' | 'name' | 'role' | 'text' | 'css'
+  /**
+   * `cdp-shadow` elements live inside a CLOSED shadow root: in-page JS cannot
+   * see them, so the kernel never resolves such a spec — the driver routes the
+   * op to the chrome.debugger (CDP) channel instead.
+   */
+  how: 'testid' | 'id' | 'name' | 'role' | 'text' | 'css' | 'cdp-shadow'
   value: string
   role?: string
   tag?: string
   /** Zero-based index among visible matches, when a spec matches several. */
   nth?: number
+  /**
+   * Shadow hosts crossed from the document root to the target, outermost
+   * first, each as a CSS selector that matches the host in LIGHT DOM (hosts
+   * always live in light DOM; only their content is shadowed). Empty/absent
+   * for plain light-DOM elements. Used to descend into open shadow roots
+   * in-page, and by the CDP channel to narrow the pierced-tree search.
+   */
+  shadowHosts?: string[]
+  /**
+   * True when the target is inside a CLOSED shadow root. Such a spec can only
+   * be resolved through chrome.debugger (DOM.getDocument pierce / Input
+   * events); the kernel treats it as unresolvable.
+   */
+  closedShadow?: boolean
 }
 
 /** Every action the kernel understands. */

--- a/tests/cdp-shadow.spec.ts
+++ b/tests/cdp-shadow.spec.ts
@@ -1,0 +1,238 @@
+/**
+ * Pure tree-parsing logic behind the CDP closed-shadow channel.
+ *
+ * `buildShadowCandidates` walks a `DOM.getDocument({ pierce: true })` tree
+ * (which expands CLOSED shadow roots) and collects interactive elements inside
+ * shadow roots; `matchCandidates` resolves a Target against them; `boxCenter`
+ * and the live click sequence are verified with a fake CDP session.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  buildShadowCandidates,
+  matchCandidates,
+  candidateToSnapshot,
+  boxCenter,
+  clickClosedShadow,
+  type CdpSession,
+} from '../src/background/cdp-shadow'
+import type { Target } from '../src/lib/ops'
+
+// A pierced CDP node tree shaped like the <xhs-publish-btn> component:
+// the host's shadowRoots[0] contains two buttons, one being 发布.
+const piercedTree = {
+  nodeId: 1,
+  nodeType: 9, // document
+  nodeName: '#document',
+  children: [
+    {
+      nodeId: 2,
+      nodeType: 1,
+      nodeName: 'XHS-PUBLISH-BTN',
+      attributes: ['id', 'publish-host'],
+      shadowRoots: [
+        {
+          nodeId: 3,
+          nodeType: 11, // shadow root (CDP marks these as fragments)
+          nodeName: '#shadow-root',
+          children: [
+            {
+              nodeId: 4,
+              nodeType: 1,
+              nodeName: 'DIV',
+              children: [
+                {
+                  nodeId: 5,
+                  nodeType: 1,
+                  nodeName: 'BUTTON',
+                  attributes: ['class', 'ce-btn white'],
+                  children: [{ nodeType: 3, nodeName: '#text', nodeValue: '暂存离开' }],
+                },
+                {
+                  nodeId: 6,
+                  nodeType: 1,
+                  nodeName: 'BUTTON',
+                  attributes: ['class', 'ce-btn bg-red', 'aria-disabled', 'false'],
+                  children: [{ nodeType: 3, nodeName: '#text', nodeValue: '发布' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      nodeId: 7,
+      nodeType: 1,
+      nodeName: 'BUTTON',
+      attributes: ['id', 'light-btn'],
+      children: [{ nodeType: 3, nodeName: '#text', nodeValue: 'Light' }],
+    },
+  ],
+}
+
+describe('buildShadowCandidates', () => {
+  it('collects interactive elements inside shadow roots but not light DOM', () => {
+    const cands = buildShadowCandidates(piercedTree)
+    const names = cands.map((c) => c.name)
+    expect(names).toContain('发布')
+    expect(names).toContain('暂存离开')
+    // The light-DOM button is not inside a shadow root.
+    expect(names).not.toContain('Light')
+  })
+
+  it('marks buttons as role=button and records the host tag chain', () => {
+    const cands = buildShadowCandidates(piercedTree)
+    const publish = cands.find((c) => c.name === '发布')
+    expect(publish).toBeTruthy()
+    expect(publish!.role).toBe('button')
+    expect(publish!.tag).toBe('button')
+    expect(publish!.hostTags).toContain('xhs-publish-btn')
+  })
+
+  it('treats aria-disabled as disabled', () => {
+    const cands = buildShadowCandidates(piercedTree)
+    const publish = cands.find((c) => c.name === '发布')
+    // aria-disabled="false" -> not disabled.
+    expect(publish!.disabled).toBe(false)
+  })
+})
+
+describe('matchCandidates', () => {
+  const target: Target = {
+    primary: { how: 'cdp-shadow', value: '发布', role: 'button', tag: 'button', closedShadow: true },
+    fallbacks: [],
+    label: '发布',
+  }
+
+  it('matches a role+name target to the right shadowed button', () => {
+    const cands = buildShadowCandidates(piercedTree)
+    const m = matchCandidates(cands, target)
+    expect(m).toBeTruthy()
+    expect(m!.name).toBe('发布')
+    expect(m!.node.nodeId).toBe(6)
+  })
+
+  it('returns null when nothing matches', () => {
+    const cands = buildShadowCandidates(piercedTree)
+    const m = matchCandidates(cands, {
+      primary: { how: 'cdp-shadow', value: '不存在的按钮', role: 'button', closedShadow: true },
+      fallbacks: [],
+    })
+    expect(m).toBeNull()
+  })
+})
+
+describe('candidateToSnapshot', () => {
+  it('emits a closed-shadow target the driver routes through CDP', () => {
+    const cands = buildShadowCandidates(piercedTree)
+    const publish = cands.find((c) => c.name === '发布')!
+    const entry = candidateToSnapshot(publish, 'e42')
+    expect(entry.ref).toBe('e42')
+    expect(entry.name).toBe('发布')
+    expect(entry.target.primary.how).toBe('cdp-shadow')
+    expect(entry.target.primary.closedShadow).toBe(true)
+  })
+})
+
+describe('boxCenter', () => {
+  it('parses the REAL CDP shape: a flat 8-number content quad', () => {
+    // DOM.getBoxModel returns model.content as [x1,y1,x2,y2,x3,y3,x4,y4].
+    // Regression: parsing this as point objects yielded NaN, which
+    // JSON.stringify turned into null and CDP rejected with
+    // "params.x mandatory field missing".
+    const center = boxCenter({
+      model: { content: [100, 200, 220, 200, 220, 240, 100, 240] },
+    })
+    expect(center).toEqual({ x: 160, y: 220 })
+  })
+
+  it('also tolerates an object-point quad', () => {
+    const center = boxCenter({
+      content: [
+        { x: 100, y: 200 },
+        { x: 220, y: 200 },
+        { x: 220, y: 240 },
+        { x: 100, y: 240 },
+      ],
+    })
+    expect(center).toEqual({ x: 160, y: 220 })
+  })
+
+  it('rejects boxes that would produce non-finite coordinates', () => {
+    expect(boxCenter({ model: { content: [] } })).toBeNull()
+    expect(boxCenter({ model: { content: [1, 2] } })).toBeNull()
+  })
+
+  it('returns null for a missing box', () => {
+    expect(boxCenter(undefined)).toBeNull()
+  })
+})
+
+describe('clickClosedShadow', () => {
+  it('dispatches trusted press/release at the matched button center', async () => {
+    const calls: Array<{ method: string; params: Record<string, unknown> }> = []
+    const session: CdpSession = {
+      send: (method, params = {}) => {
+        calls.push({ method, params })
+        if (method === 'DOM.getDocument') return Promise.resolve({ root: piercedTree })
+        if (method === 'DOM.getBoxModel') {
+          // REAL CDP shape: flat number quad, not point objects.
+          return Promise.resolve({
+            model: { content: [100, 200, 220, 200, 220, 240, 100, 240] },
+          })
+        }
+        return Promise.resolve({})
+      },
+    }
+    const target: Target = {
+      primary: { how: 'cdp-shadow', value: '发布', role: 'button', closedShadow: true },
+      fallbacks: [],
+    }
+    const out = await clickClosedShadow(session, target)
+    expect(out.ok).toBe(true)
+
+    const events = calls.filter((c) => c.method === 'Input.dispatchMouseEvent')
+    expect(events.map((e) => e.params.type)).toEqual(['mousePressed', 'mouseReleased'])
+    expect(events[0]!.params).toMatchObject({ x: 160, y: 220, button: 'left' })
+  })
+
+  it('falls back to a node click when the box model is unavailable', async () => {
+    const calls: Array<{ method: string; params: Record<string, unknown> }> = []
+    const session: CdpSession = {
+      send: (method, params = {}) => {
+        calls.push({ method, params })
+        if (method === 'DOM.getDocument') return Promise.resolve({ root: piercedTree })
+        if (method === 'DOM.getBoxModel') return Promise.reject(new Error('no box'))
+        if (method === 'DOM.resolveNode') {
+          return Promise.resolve({ object: { objectId: 'obj-1' } })
+        }
+        return Promise.resolve({})
+      },
+    }
+    const out = await clickClosedShadow(session, {
+      primary: { how: 'cdp-shadow', value: '发布', role: 'button', closedShadow: true },
+      fallbacks: [],
+    })
+    expect(out.ok).toBe(true)
+    const methods = calls.map((c) => c.method)
+    expect(methods).toContain('DOM.resolveNode')
+    expect(methods).toContain('Runtime.callFunctionOn')
+    const fn = calls.find((c) => c.method === 'Runtime.callFunctionOn')
+    expect(fn!.params.functionDeclaration).toContain('this.click()')
+  })
+
+  it('reports failure when the element is absent from the pierced tree', async () => {
+    const session: CdpSession = {
+      send: (method) => {
+        if (method === 'DOM.getDocument') return Promise.resolve({ root: piercedTree })
+        return Promise.resolve({})
+      },
+    }
+    const out = await clickClosedShadow(session, {
+      primary: { how: 'cdp-shadow', value: '不存在', role: 'button', closedShadow: true },
+      fallbacks: [],
+    })
+    expect(out.ok).toBe(false)
+    expect(out.error).toContain('未找到')
+  })
+})

--- a/tests/kernel-shadow.spec.ts
+++ b/tests/kernel-shadow.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * Open shadow-DOM support in the in-page kernel.
+ *
+ * Elements inside an OPEN shadow root must be visible to snapshot, carry a
+ * shadowHosts chain in their target specs, be re-resolvable by the target, and
+ * be clickable; an element inside a CLOSED shadow root is unreachable in-page
+ * (the driver routes it through chrome.debugger), so a cdp-shadow spec is
+ * treated as not found by the kernel.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { JSDOM } from 'jsdom'
+import { runOp } from '../src/inpage/kernel'
+import type { Op, Target } from '../src/lib/ops'
+
+let dom: JSDOM
+
+function makePage(opts: { closed?: boolean } = {}): void {
+  dom = new JSDOM(
+    `<!DOCTYPE html><body>
+      <button id="light-btn">Light</button>
+      <xhs-publish-btn id="publish-host"></xhs-publish-btn>
+    </body>`,
+    { url: 'https://example.test/', pretendToBeVisual: true },
+  )
+  const g = globalThis as unknown as Record<string, unknown>
+  g.window = dom.window
+  g.self = dom.window
+  g.top = dom.window
+  g.document = dom.window.document
+  g.location = dom.window.location
+  g.HTMLElement = dom.window.HTMLElement
+  g.HTMLInputElement = dom.window.HTMLInputElement
+  g.HTMLButtonElement = dom.window.HTMLButtonElement
+  g.HTMLAnchorElement = dom.window.HTMLAnchorElement
+  g.HTMLSelectElement = dom.window.HTMLSelectElement
+  g.HTMLTextAreaElement = dom.window.HTMLTextAreaElement
+  g.HTMLFormElement = dom.window.HTMLElement
+  g.ShadowRoot = dom.window.ShadowRoot
+  g.DocumentFragment = dom.window.DocumentFragment
+  g.MouseEvent = dom.window.MouseEvent
+  g.PointerEvent = dom.window.PointerEvent
+  g.Event = dom.window.Event
+  g.Node = dom.window.Node
+  g.Element = dom.window.Element
+  g.getComputedStyle = dom.window.getComputedStyle.bind(dom.window)
+
+  const host = dom.window.document.getElementById('publish-host') as HTMLElement
+  const root = host.attachShadow({ mode: opts.closed ? 'closed' : 'open' })
+  root.innerHTML = `
+    <div class="publish-page-publish-btn">
+      <button type="button" class="ce-btn white">暂存离开</button>
+      <button type="button" class="ce-btn bg-red" aria-disabled="false">发布</button>
+    </div>`
+}
+
+beforeEach(() => {
+  makePage({ closed: false })
+})
+
+describe('kernel open shadow DOM', () => {
+  it('snapshot sees interactive elements inside an open shadow root', () => {
+    const result = runOp({ action: 'snapshot' } as Op)
+    expect(result.ok).toBe(true)
+    const names = (result.page?.elements ?? []).map((e) => e.name)
+    expect(names).toContain('发布')
+    expect(names).toContain('暂存离开')
+    expect(names).toContain('Light')
+  })
+
+  it('target for a shadowed element carries a shadowHosts chain', () => {
+    const result = runOp({ action: 'snapshot' } as Op)
+    const publish = (result.page?.elements ?? []).find((e) => e.name === '发布')
+    expect(publish).toBeTruthy()
+    const chain = publish!.target.primary.shadowHosts
+    expect(chain && chain.length >= 1).toBe(true)
+    // The host step is a light-DOM selector for <xhs-publish-btn>.
+    expect(chain!.join(' ')).toContain('xhs-publish-btn')
+  })
+
+  it('resolves a shadowed element via its snapshot target and clicks it', () => {
+    const result = runOp({ action: 'snapshot' } as Op)
+    const publish = (result.page?.elements ?? []).find((e) => e.name === '发布')
+    expect(publish).toBeTruthy()
+
+    let clicked = 0
+    const host = dom.window.document.getElementById('publish-host') as HTMLElement
+    const shadowBtn = host.shadowRoot!.querySelector('button.bg-red') as HTMLElement
+    shadowBtn.addEventListener('click', () => { clicked += 1 })
+
+    const clickResult = runOp({ action: 'click', target: publish!.target } as Op)
+    expect(clickResult.ok).toBe(true)
+    expect(clicked).toBe(1)
+  })
+
+  it('wait_for finds a shadowed element through its target', () => {
+    const result = runOp({ action: 'snapshot' } as Op)
+    const publish = (result.page?.elements ?? []).find((e) => e.name === '发布')
+    const wait = runOp({ action: 'wait_for', target: publish!.target } as Op)
+    expect(wait.ok).toBe(true)
+    expect(wait.found).toBe(true)
+  })
+
+  it('treats a cdp-shadow (closed) spec as unresolvable in-page', () => {
+    const target: Target = {
+      primary: { how: 'cdp-shadow', value: '发布', role: 'button', tag: 'button', closedShadow: true },
+      fallbacks: [],
+    }
+    const result = runOp({ action: 'click', target } as Op)
+    expect(result.found).toBe(false)
+  })
+
+  it('closed shadow root elements are NOT visible to in-page snapshot', () => {
+    makePage({ closed: true })
+    const result = runOp({ action: 'snapshot' } as Op)
+    const names = (result.page?.elements ?? []).map((e) => e.name)
+    expect(names).not.toContain('发布')
+    expect(names).toContain('Light')
+  })
+})


### PR DESCRIPTION
<xhs-publish-btn> and similar components render their buttons in a CLOSED shadow root: in-page JS cannot see the root, document queries never reach the inner buttons, and synthetic events on the host do not cross the shadow boundary, so snapshots missed them and clicks silently hit nothing.

- cdp-shadow (new): pierce the tree with DOM.getDocument({pierce:true}), collect interactive shadowed elements, and click/hover them through trusted Input.dispatchMouseEvent at the resolved box center; fall back to a Runtime.callFunctionOn node click when no box exists. boxCenter parses the REAL flat 8-number content quad (the point-object shape produced NaN coords and CDP rejected "params.x missing").
- driver: route closed-shadow targets to the CDP channel, merge shadowed elements into snapshots (prepended + renumbered), and serialize all chrome.debugger sessions per tab through one helper.
- kernel: query/snapshot/forms walk open shadow roots; specs carry a shadowHosts chain; the occlusion check no longer treats the shadow host as a blocker; cdp-shadow specs resolve to not-found in-page.
- picker/record: use composedPath()[0] so open-shadow elements can be picked and recorded (closed roots still resolve to the host).
- agent: keep each snapshot element target in the model-facing summary (it was stripped, so click/fill could not echo it back); it carries the closedShadow marker that routes clicks through CDP.
- ops: TargetSpec gains the "cdp-shadow" how plus shadowHosts/closedShadow.

Tests: kernel open-shadow snapshot/click/wait_for, CDP candidate matching against the pierced tree, real flat-quad box parsing, and the fallback node click.